### PR TITLE
implement a simple API-based `nupm install`

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,5 +1,26 @@
 use std log
 
+def throw-error [
+    error: string
+    text?: string
+    --span: record<start: int, end: int>
+] {
+    let error = $"(ansi red_bold)($error)(ansi reset)"
+
+    if $span == null {
+        error make --unspanned { msg: $error }
+    }
+
+    error make {
+        msg: $error
+        label: {
+            text: ($text | default "this caused an internal error")
+            start: $span.start
+            end: $span.end
+        }
+    }
+}
+
 # install a Nuhshell package
 #
 # > **Warning**  

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -37,4 +37,14 @@ export def main [
     url: string  # the URL to the root of the repo holding the package
     --path: string  # if the package is not the repo itself, gives the path to it
 ] {
+    log debug $"parsing URL ($url)"
+    let url_tokens = (try {
+        $url | url parse | select scheme host path
+    } catch {
+        throw-error "invalid_url" "not a valid URL" --span (metadata $url | get span)
+    })
+
+    if $url_tokens.host != "github.com" {
+        throw-error "invalid_host" $"($url_tokens.host) is not a supported host" --span (metadata $url | get span)
+    }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -46,7 +46,7 @@ def query-github-api [
     }
 }
 
-# install a Nuhshell package
+# install a Nushell package
 #
 # > **Warning**  
 # > - only supports GitHub packages

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -136,4 +136,6 @@ export def main [
 
         $files = ($files | where type == file | append $sub_files)
     }
+
+    # TODO: pull down the files into the local `nupm` store
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,0 +1,19 @@
+use std log
+
+# install a Nuhshell package
+#
+# > **Warning**  
+# > - only supports GitHub packages
+# > - a package needs to have a `package.nuon` file at its root with some keys
+#
+# # Examples
+#     install a repo package
+#     > nupm install https://github.com/amtoine/nu-git-manager
+#
+#     install a subpath package
+#     > nupm install https://github.com/amtoine/zellij-layouts --path nu-zellij
+export def main [
+    url: string  # the URL to the root of the repo holding the package
+    --path: string  # if the package is not the repo itself, gives the path to it
+] {
+}

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -40,7 +40,7 @@ def query-github-api [
         )
     } catch {|e|
         if ($e.msg == "Network failure") and ($e.debug | str contains "Access forbidden (403)") {
-            throw-error "could not reach GitHub (you might have reached the API limit, please try again later)"
+            throw-error "github_api_limit_reached: could not reach GitHub (you might have reached the API limit, please try again later)"
         }
         return $e.raw
     }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -80,10 +80,7 @@ export def main [
         $url_tokens
         | update host "raw.githubusercontent.com"
         | update path {
-            append $default_branch
-            | if $path != null { append $path } else {}
-            | append "package.nuon"
-            | str join "/"
+            append [$default_branch $path "package.nuon"] | str join "/"
         }
         | url join
     )


### PR DESCRIPTION
in this PR, i've tried to implement the `nupm install` command.

## signature and doc
```nu
# install a Nushell package
#
# > **Warning**  
# > - only supports GitHub packages
# > - a package needs to have a `package.nuon` file at its root with some keys
#
# # Examples
#     install a repo package
#     > nupm install https://github.com/amtoine/nu-git-manager
#
#     install a subpath package
#     > nupm install https://github.com/amtoine/zellij-layouts --path nu-zellij
install [
    url: string  # the URL to the root of the repo holding the package
    --path: string  # if the package is not the repo itself, gives the path to it
]
```

## how it works (in order in the command)
> **Note**
> `nupm install` uses `std log` to add logging information, do not forget to turn on debug mode, e.g. with `$env.NU_LOG_LEVEL = 0`, to see all messages
- parse the URL and makes sure it's a GitHub one
- get the default branch with the API
- pull the *package* file and checks its integrity
- crawl the package files with the API to draw the list of all the files recursively

## errors and limitations
`nupm install` throws the following errors, with a nice format
- `invalid_url` when the `url` cannot be parsed
- `invalid_host` when the `host` is not `'github.com"`
- `package_file_not_found` when the root of the package does not have a *package* file
- `invalid_package_file` when the *package* file is invalid, i.e. when it misses some required keys
- `github_api_limit_reached` when the *GitHub* API limit has been reached...

> **Warning**
> the main limitation of the command right now is the `query-github-api` command which is limited by the API itself...

> **Note**
> TODO: pull down the files after building the list