### PR TITLE
FEATURE: add a command to install a local Nushell package

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -2,7 +2,7 @@ use std log
 
 # install a Nushell package
 export def main [
-    --path: path  # the path to the local source of the package (default to the current directory)
+    --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {
     let path = ($path | default . | path expand)
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,5 +1,13 @@
 use std log
 
+def nupm-home [] {
+    $env.NUPM_HOME? | default (
+        $env.XDG_DATA_HOME?
+        | default ($nu.home-path | path join ".local" "share")
+        | path join "nupm"
+    )
+}
+
 # install a Nushell package
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -39,24 +39,10 @@ def open-package-file [path: path] {
     let package = (open $package_file)
 
     log debug "checking package file for missing required keys"
+    let required_keys = [$. $.name $.version $.description $.license]
     let missing_keys = (
-        [
-            [key required];
-
-            [$. true]
-            [$.name true]
-            [$.version true]
-            [$.description true]
-            [$.license true]
-        ] | each {|key|
-            if ($package | get --ignore-errors $key.key) == null {
-                $key
-            }
-        }
-        | where required
-        | get key
+        $required_keys | where {|key| ($package | get -i $key) == null}
     )
-
     if not ($missing_keys | is-empty) {
         throw-error $"invalid_package_file(ansi reset):\n($package_file) is missing the following required keys: ($missing_keys | str join ', ')"
     }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,26 +1,5 @@
 use std log
 
-def throw-error [
-    error: string
-    text?: string
-    --span: record<start: int, end: int>
-] {
-    let error = $"(ansi red_bold)($error)(ansi reset)"
-
-    if $span == null {
-        error make --unspanned { msg: $error }
-    }
-
-    error make {
-        msg: $error
-        label: {
-            text: ($text | default "this caused an internal error")
-            start: $span.start
-            end: $span.end
-        }
-    }
-}
-
 def nupm-home [] {
     $env.NUPM_HOME? | default (
         $env.XDG_DATA_HOME?
@@ -51,6 +30,7 @@ export def main [
         }
     } else {
         # TODO: add support for updating / reinstalling a package in that case
-        throw-error $"package ($package.name) is already installed"
+        log warning $"($package.name) is already installed."
+        return
     }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -35,6 +35,7 @@ export def main [
 ] {
     let path = ($path | default . | path expand)
 
+    # NOTE: here, we suppose that the package file exists and is valid
     let package = ($path | path join "package.nuon" | open)
 
     let destination = (nupm-home | path join $package.name)

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -22,11 +22,10 @@ export def main [
         log info $"installing package ($package.name)"
         log debug $"source: ($path)"
         log debug $"destination: ($destination)"
-        cp --recursive $path $destination
-
-        if ($destination | path join ".git" | path exists) {
-            log debug $"removing .git directory from ($destination)"
-            rm --recursive ($destination | path join ".git")
+        mkdir $destination
+        ls ($path | path join "**" "*") | where name !~ '^.git' | each {|it|
+            log debug $"($it.name | str replace $path "" | str trim --left --char "/")"
+            cp --recursive $it.name $destination
         }
     } else {
         # TODO: add support for updating / reinstalling a package in that case

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -43,6 +43,11 @@ export def main [
         log debug $"source: ($path)"
         log debug $"destination: ($destination)"
         cp --recursive $path $destination
+
+        if ($destination | path join ".git" | path exists) {
+            log debug $"removing .git directory from ($destination)"
+            rm --recursive ($destination | path join ".git")
+        }
     } else {
         throw-error $"package ($package.name) is already installed"
     }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -21,7 +21,7 @@ def copy-directory-to [destination: path] {
     log debug $"destination: ($destination)"
 
     ls --all $source | where name != ".git" | each {|it|
-        log debug ($it.name | str replace $source "" | str trim --left --char "/")
+        log debug ($it.name | str replace $source "" | str trim --left --char (char path_sep))
         cp --recursive $it.name $destination
     }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,11 +1,7 @@
 use std log
 
 def nupm-home [] {
-    $env.NUPM_HOME? | default (
-        $env.XDG_DATA_HOME?
-        | default ($nu.home-path | path join ".local" "share")
-        | path join "nupm"
-    )
+    $env.NUPM_HOME? | default ($nu.default-config-dir | path join "nupm")
 }
 
 def throw-error [

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -23,8 +23,8 @@ export def main [
         log debug $"source: ($path)"
         log debug $"destination: ($destination)"
         mkdir $destination
-        ls ($path | path join "**" "*") | where name !~ '^.git' | each {|it|
-            log debug $"($it.name | str replace $path "" | str trim --left --char "/")"
+        ls --all $path | where name != ".git" | each {|it|
+            log debug ($it.name | str replace $path "" | str trim --left --char "/")
             cp --recursive $it.name $destination
         }
     } else {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,0 +1,12 @@
+use std log
+
+# install a Nushell package
+export def main [
+    --path: path  # the path to the local source of the package (default to the current directory)
+] {
+    let path = ($path | default . | path expand)
+
+    log debug $"path: ($path)"
+
+    throw-error "installing packages is not supported"
+}

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -49,6 +49,7 @@ export def main [
             rm --recursive ($destination | path join ".git")
         }
     } else {
+        # TODO: add support for updating / reinstalling a package in that case
         throw-error $"package ($package.name) is already installed"
     }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -15,6 +15,11 @@ def prepare-directory [directory: path] {
 
 def copy-directory-to [destination: path] {
     let source = $in
+
+    log info "copying directory"
+    log debug $"source: ($source)"
+    log debug $"destination: ($destination)"
+
     ls --all $source | where name != ".git" | each {|it|
         log debug ($it.name | str replace $source "" | str trim --left --char "/")
         cp --recursive $it.name $destination
@@ -32,8 +37,6 @@ export def main [
     log info $"installing package ($package.name)"
 
     let destination = (nupm-home | path join $package.name)
-    log debug $"source: ($path)"
-    log debug $"destination: ($destination)"
 
     prepare-directory $destination
     $path | copy-directory-to $destination

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -72,7 +72,7 @@ def copy-directory-to [destination: path] {
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {
-    let path = ($path | default . | path expand)
+    let path = ($path | default $env.PWD)
     let package = (open-package-file $path)
 
     log info $"installing package ($package.name)"


### PR DESCRIPTION
# Description
this PR implements a start for the `nupm install` command:
- installs only local packages, i.e. the files have to be pulled with things like `git` or downloading archives before hand
- defaults to installing the package in the root of the repo
- can be changed with the `--path` option in the case the package is in a subdirectory
- assumes the *package* file exists and is valid
- installs the package by simply copying the files from the repo to the local home of `nupm`

# Note for reviewers
in order to try this with eveything enabled, i use the following commands
```nu
use /path/to/nupm/nupm/
$env.NU_LOG_LEVEL = $env.LOG_LEVEL.DEBUG
$env.NUPM_HOME = ($nu.temp-path | path join "nupm")
```
and then try
```nu
nupm install
# or
nupm install --path .
```
from [`amtoine/nu-git-manager`](https://github.com/amtoine/nu-git-manager)
and
```nu
nupm install --path nu-zellij/
# or
nupm install --path nu-zellij
```
from [`amtoine/zellij-layouts`](https://github.com/amtoine/zellij-layouts) which contains the `nu-zellij` package