### PR TITLE
do not install the Git directory of a package

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -58,7 +58,9 @@ def copy-directory-to [destination: path] {
     log debug $"source: ($source)"
     log debug $"destination: ($destination)"
 
-    ls --all $source | where name != ".git" | each {|it|
+    ls --all $source
+    | where {|it| not ($it.type == dir and ($it.name | path parse | get stem) == ".git")}
+    | each {|it|
         log debug ($it.name | str replace $source "" | str trim --left --char (char path_sep))
         cp --recursive $it.name $destination
     }


### PR DESCRIPTION
i've noticed, in case the local package has been pulled via Git, that `nupm install` would install the `.git/` directory.

this is because `name != ".git"` is a weak test given the fact that the paths are absolute because `source` is an absolute path in `copy-directory-to`.

this PR removes the `.git/` directory from the copied items by checking it more strongly.