### PR TITLE
throw an error when `--path` is not raised

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -68,7 +68,10 @@ def copy-directory-to [destination: path] {
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {
-    let path = ($path | default $env.PWD)
+    if $path == null {
+        throw-error "`nupm install` requires a `--path`"
+    }
+
     let package = (open-package-file $path)
 
     log info $"installing package ($package.name)"


### PR DESCRIPTION
in the future, we will be able to `nupm install <name of package>`, so i think it does not make much sense to default `nupm install` to `nupm install --path .

and as we do not support installing a package by name or URL, i propose to throw an error when running `nupm install` with the `--path` option :+1: 

## inspiration
```
> cargo install
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
```