### PR TITLE
add support for installation type to `nupm install`

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -110,7 +110,14 @@ export def main [
 
             install-scripts $path $package
         },
-        "custom" => { log info "custom install coming soon" },
+        "custom" => {
+            if not ($path | path join "build.nu" | path exists) {
+                let text = $"package uses a custom install but no `build.nu` has been found"
+                throw-error "invalid_package_file" $text --span (metadata $path | get span)
+            }
+
+            nu ($path | path join 'build.nu')
+        },
         _ => {
             let text = $"expected `$.type` to be one of [module, script, custom], got ($package.type)"
             throw-error "invalid_package_file" $text --span (metadata $path | get span)

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -96,6 +96,11 @@ export def main [
 
             prepare-directory $destination
             $path | copy-directory-to $destination
+
+            if $package.scripts? != null {
+                log debug $"installing scripts for package ($package.name)"
+                install-scripts $path $package
+            }
         },
         "script" => {
             if "scripts" not-in $package {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -76,8 +76,18 @@ export def main [
 
     log info $"installing package ($package.name)"
 
-    let destination = nupm-home | path join $package.name
+    match $package.type {
+        "module" => {
+            let destination = nupm-home | path join $package.name
 
-    prepare-directory $destination
-    $path | copy-directory-to $destination
+            prepare-directory $destination
+            $path | copy-directory-to $destination
+        },
+        "script" => { log info "script install coming soon" },
+        "custom" => { log info "custom install coming soon" },
+        _ => {
+            let text = $"expected `$.type` to be one of [module, script, custom], got ($package.type)"
+            throw-error "invalid_package_file" $text --span (metadata $path | get span)
+        },
+    }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -69,12 +69,17 @@ def install-scripts [path: path, package: record<scripts: list<path>>]: nothing 
     mkdir $nupm_bin
 
     for script in $package.scripts {
+        let script_path = $path | path join $script
         let name = $script | path basename
         let destination = $nupm_bin | path join $name
 
-        log debug $"installing script `($name)` to `($destination)`"
-        cp ($path | path join $script) $destination
-        chmod +x $destination
+        if ($script_path | path exists) {
+            log debug $"installing script `($name)` to `($destination)`"
+            cp $script_path $destination
+            chmod +x $destination
+        } else {
+            log warning $"($script_path) could not be found, skipping"
+        }
     }
 }
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -35,7 +35,7 @@ def open-package-file [path: path] {
     let package = open $package_file
 
     log debug "checking package file for missing required keys"
-    let required_keys = [$. $.name $.version $.description $.license]
+    let required_keys = [$. $.name $.version $.description $.license $.type]
     let missing_keys = $required_keys | where {|key| ($package | get -i $key) == null}
     if not ($missing_keys | is-empty) {
         throw-error $"invalid_package_file(ansi reset):\n($package_file) is missing the following required keys: ($missing_keys | str join ', ')"


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/issues/10

might even close https://github.com/nushell/nupm/issues/10 as the "custom" install is super general

cc/ @skelly37

## description
this PR adds support to specifying the installation type in `package.nuon` so that `nupm install` can adapt to different types of packages.

### `type: "module"`
this is as before this PR, i.e. the whole directory is installed in `nupm-home`.
additionaly, `$.scripts: list<path>` can give a list of optional scripts to be installed in `nupm-home | path join "bin"`
```nushell
{
    name: "nu-goat-scripts"
    version: 0.1.0
    description: "The collection of `nushell` scripts for GOATs."
    documentation: "https://github.com/goatfiles/scripts/blob/main/nu_scripts/README.md"
    maintainers: [
        @amtoine
        @atxr
    ]
    license: "https://github.com/goatfiles/scripts/blob/main/LICENSE"
    type: "module"
    scripts: [
        "scripts/gh-notifications.nu"
        "scripts/happy-day.nu"
        "scripts/kill-systemd-service.nu"
        "scripts/nupm-update.nu"
        "scripts/nushell-news.nu"
        "scripts/passme.nu"
        "scripts/plot-startup-times.nu"
        "scripts/tmux-sessionizer.nu"
        "scripts/xrandr-brightness.nu"
        "scripts/xrandr-tui.nu"
        "scripts/xrandr.nu"
    ]
}
```

### `type: "script"`
this one requires the definition of `$.scripts: list<path>` in `package.nuon` and will only install these files in `nupm-home | path join "bin"`
```nushell
{
    name: "nu-clippy"
    description: "a linter written in `nu` for the Nushell programming language"
    version: 0.1.0
    documentation: "https://github.com/goatfiles/scripts/blob/main/nu-clippy/README.md"
    license: "https://github.com/goatfiles/scripts/blob/main/LICENSE"
    type: "script"
    scripts: ["clippy.nu"]
}
```

### `type: "custom"`
this last one is the most general and just requires a `build.nu` file to be in the root of the repo.
`nupm install` will run the `build.nu` script and that's it.
`build.nu` does not need to be executable.

this should allow to install anything, including plugins
```nushell
{
    name: "nu_plugin_kdl"
    version: 0.1.0
    description: "A plugin to add KDL support to Nushell."
    documentation: "https://github.com/amtoine/nu_plugin_kdl/blob/main/README.md"
    maintainers: [@amtoine]
    license: "https://github.com/amtoine/nu_plugin_kdl/blob/main/LICENSE"
    type: "custom"
}
```
and
```nushell
# build.nu
cargo build --release
nu --no-config-file --commands "register target/release/nu_plugin_kdl"
```
should allow to install my [`nu_plugin_kdl`](https://github.com/amtoine/nu_plugin_kdl) plugin :ok_hand: 