### PR TITLE
Add main nupm command; Start dirs module

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,9 +1,5 @@
 use std log
 
-def nupm-home [] {
-    $env.NUPM_HOME? | default ($nu.default-config-dir | path join "nupm")
-}
-
 def throw-error [
     error: string
     text?: string
@@ -65,7 +61,7 @@ def copy-directory-to [destination: path] {
 }
 
 def install-scripts [path: path, package: record<scripts: list<path>>]: nothing -> nothing {
-    let nupm_bin = nupm-home | path join "bin"
+    let nupm_bin = $env.NUPM_HOME | path join "bin"
     mkdir $nupm_bin
 
     for script in $package.scripts {
@@ -97,7 +93,7 @@ export def main [
 
     match $package.type {
         "module" => {
-            let destination = nupm-home | path join $package.name
+            let destination = $env.NUPM_HOME | path join $package.name
 
             prepare-directory $destination
             $path | copy-directory-to $destination

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,5 +1,7 @@
 use std log
 
+use utils/dirs.nu nupm-home-prompt
+
 def throw-error [
     error: string
     text?: string
@@ -88,6 +90,7 @@ export def main [
     }
 
     let package = open-package-file $path
+    print $package
 
     log info $"installing package ($package.name)"
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -79,7 +79,7 @@ def install-scripts [path: path, package: record<scripts: list<path>>]: nothing 
     }
 }
 
-# install a Nushell package
+# Install a nupm package
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -90,7 +90,6 @@ export def main [
     }
 
     let package = open-package-file $path
-    print $package
 
     log info $"installing package ($package.name)"
 

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,0 +1,13 @@
+use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
+
+export-env {
+    if 'NUPM_HOME' not-in $env {
+        $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
+    }
+}
+
+export def main [] {
+    nupm-home-prompt
+
+    print 'enjoy nupm!'
+}

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,7 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    $env.NUPM_HOME = ($env.NUPM_HOME? | $DEFAULT_NUPM_HOME)
+    $env.NUPM_HOME = ($env.NUPM_HOME? | default $DEFAULT_NUPM_HOME)
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,9 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    if 'NUPM_HOME' not-in $env {
-        $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
-    }
+    $env.NUPM_HOME = $env.NUPM_HOME? | $DEFAULT_NUPM_HOME
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,7 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    $env.NUPM_HOME = $env.NUPM_HOME? | $DEFAULT_NUPM_HOME
+    $env.NUPM_HOME = ($env.NUPM_HOME? | $DEFAULT_NUPM_HOME)
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -2,7 +2,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
-    # $env.NUPM_HOME is found during any nupm execution, it's a bug.
+    # $env.NUPM_HOME during nupm execution is a bug.
     if 'NUPM_HOME' not-in $env {
         $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
     }

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,11 +1,14 @@
 use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 
 export-env {
+    # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
+    # $env.NUPM_HOME is found during any nupm execution, it's a bug.
     if 'NUPM_HOME' not-in $env {
         $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
     }
 }
 
+# Nushell Package Manager
 export def main [] {
     nupm-home-prompt
 

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -36,13 +36,4 @@ export def nupm-home-prompt [] {
     }
 
     mkdir $env.NUPM_HOME
-
-    let bin_dir = ($env.NUPM_HOME | path join bin)
-    let overlays_dir = ($env.NUPM_HOME | path join overlays)
-
-    mkdir $bin_dir
-    mkdir $overlays_dir
-
-    print ($"Don't forget to add ($bin_dir) to PATH/Path"
-        + $" and ($overlays_dir) to NU_LIB_DIRS environment variables!")
 }

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -1,0 +1,45 @@
+export const TMP_DIR = ($nu.temp-path | path join nupm)
+export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
+
+export def nupm-home-prompt [] {
+    if 'NUPM_HOME' not-in $env {
+        error make {
+            msg: "Internal error: NUPM_HOME environment variable is not set"
+        }
+    }
+
+    if ($env.NUPM_HOME | path exists) {
+        if ($env.NUPM_HOME | path type) != 'dir' {
+            error make {
+                msg: ($"Root directory ($env.NUPM_HOME) exists, but is not a"
+                    + "directory. Make sure $env.NUPM_HOME points at a valid"
+                    + "directory and try again.")
+            }
+        }
+
+        return
+    }
+
+    mut answer = ''
+
+    while ($answer | str downcase) not-in [ y n ] {
+        $answer = (input (
+            $'Root directory "($env.NUPM_HOME)" does not exist.'
+            + ' Do you want to create it? [y/n] '))
+    }
+
+    if ($answer | str downcase) != 'y' {
+        return
+    }
+
+    mkdir $env.NUPM_HOME
+
+    let bin_dir = ($env.NUPM_HOME | path join bin)
+    let overlays_dir = ($env.NUPM_HOME | path join overlays)
+
+    mkdir $bin_dir
+    mkdir $overlays_dir
+
+    print ($"Don't forget to add ($bin_dir) to PATH/Path"
+        + $" and ($overlays_dir) to NU_LIB_DIRS environment variables!")
+}

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -6,17 +6,17 @@ export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 export def nupm-home-prompt [] {
     if 'NUPM_HOME' not-in $env {
-        error make {
+        error make --unspanned {
             msg: "Internal error: NUPM_HOME environment variable is not set"
         }
     }
 
     if ($env.NUPM_HOME | path exists) {
         if ($env.NUPM_HOME | path type) != 'dir' {
-            error make {
+            error make --unspanned {
                 msg: ($"Root directory ($env.NUPM_HOME) exists, but is not a"
-                    + "directory. Make sure $env.NUPM_HOME points at a valid"
-                    + "directory and try again.")
+                    + " directory. Make sure $env.NUPM_HOME points at a valid"
+                    + " directory and try again.")
             }
         }
 

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -1,6 +1,9 @@
-export const TMP_DIR = ($nu.temp-path | path join nupm)
+# Directories and related utilities used in nupm
+
+# Decault installation path for nupm packages
 export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
 
+# Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 export def nupm-home-prompt [] {
     if 'NUPM_HOME' not-in $env {
         error make {


### PR DESCRIPTION
This PR adds the top-level `nupm` command, which prompts creating `$env.NUPM_HOME` if it doesn't exist. `$env.NUPM_HOME` is considered to be the default install location of nupm packages and should be always set—either by the user manually, or automatically by nupm itself.

I'm mostly feeling around the code, trying to add small changes first. I'm planning to do a few smaller refactors, eventually bringing some ideas from [`nuun`](https://github.com/kubouch/nuun) I had in mind into nupm.