### PR TITLE
Refactor `nupm install`

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -145,11 +145,12 @@ def install-path [
             }
 
             let tmp_dir = tmp-dir build --ensure
-            cd $tmp_dir
 
-            nu $build_file ($pkg_dir | path join 'package.nuon')
+            do {
+                cd $tmp_dir
+                nu $build_file ($pkg_dir | path join 'package.nuon')
+            }
 
-            cd -
             rm -rf $tmp_dir
         },
         _ => {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,9 +1,5 @@
 use std log
 
-def nupm-home [] {
-    $env.NUPM_HOME? | default ($nu.default-config-dir | path join "nupm")
-}
-
 def throw-error [
     error: string
     text?: string
@@ -65,7 +61,7 @@ def copy-directory-to [destination: path] {
 }
 
 def install-scripts [path: path, package: record<scripts: list<path>>]: nothing -> nothing {
-    let nupm_bin = nupm-home | path join "bin"
+    let nupm_bin = $env.NUPM_HOME | path join "bin"
     mkdir $nupm_bin
 
     for script in $package.scripts {
@@ -97,7 +93,7 @@ export def main [
 
     match $package.type {
         "module" => {
-            let destination = nupm-home | path join $package.name
+            let destination = $env.NUPM_HOME | path join $package.name
 
             prepare-directory $destination
             $path | copy-directory-to $destination

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -33,7 +33,7 @@ def open-package-file [path: path] {
     let package = open $package_file
 
     log debug "checking package file for missing required keys"
-    let required_keys = [$. $.name $.version $.description $.license $.type]
+    let required_keys = [$. $.name $.version $.type]
     let missing_keys = $required_keys | where {|key| ($package | get -i $key) == null}
     if not ($missing_keys | is-empty) {
         throw-error $"invalid_package_file(ansi reset):\n($package_file) is missing the following required keys: ($missing_keys | str join ', ')"

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -72,7 +72,7 @@ def install-scripts [
 
         if ($tgt_path | path type) == file and (not $force) {
             throw-error ($"Script ($src_path) is already installed as"
-                + $" ($tgt_path)")
+                + $" ($tgt_path). Use `--force` to override the package.")
         }
 
         log debug $"installing script `($src_path)` to `($scripts_dir)`"
@@ -110,7 +110,8 @@ def install-path [
             }
 
             if ($destination | path type) == dir {
-                throw-error $"Package ($package.name) is already installed"
+                throw-error ($"Package ($package.name) is already installed."
+                    + "Use `--force` to override the package")
             }
 
             cp --recursive $mod_dir $module_dir

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -162,7 +162,7 @@ def install-path [
 
 # Install a nupm package
 export def main [
-    name    # Name, path, or link to the package
+    package # Name, path, or link to the package
     --path  # Install package from a directory with package.nuon given by 'name'
     --force(-f)  # Overwrite already installed package
 ]: nothing -> nothing {
@@ -172,5 +172,5 @@ export def main [
         throw-error "`nupm install` currently requires a `--path` flag"
     }
 
-    install-path $name --force $force
+    install-path $package --force $force
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,5 +1,7 @@
 use std log
 
+use utils/dirs.nu nupm-home-prompt
+
 def throw-error [
     error: string
     text?: string
@@ -88,6 +90,7 @@ export def main [
     }
 
     let package = open-package-file $path
+    print $package
 
     log info $"installing package ($package.name)"
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -79,7 +79,7 @@ def install-scripts [path: path, package: record<scripts: list<path>>]: nothing 
     }
 }
 
-# install a Nushell package
+# Install a nupm package
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -60,7 +60,7 @@ def open-package-file [dir: path] {
 def install-scripts [
     pkg_dir: path        # Package directory
     scripts_dir: path    # Target directory where to install
-    --force(-f)          # Overwrite already installed scripts
+    --force(-f): bool    # Overwrite already installed scripts
 ] {
     each {|script|
         let src_path = $pkg_dir | path join $script
@@ -82,8 +82,8 @@ def install-scripts [
 
 # Install package from a directory containing 'project.nuon'
 def install-path [
-    pkg_dir: path  # Directory (hopefully) containing 'package.nuon'
-    --force(-f)    # Overwrite already installed package
+    pkg_dir: path      # Directory (hopefully) containing 'package.nuon'
+    --force(-f): bool  # Overwrite already installed package
 ] {
     let pkg_dir = $pkg_dir | path expand --strict
 
@@ -115,11 +115,9 @@ def install-path [
 
             if $package.scripts? != null {
                 log debug $"installing scripts for package ($package.name)"
-                $package.scripts | if $force {
-                    install-scripts --force $pkg_dir (script-dir --ensure)
-                } else {
-                    install-scripts $pkg_dir (script-dir --ensure)
-                }
+
+                $package.scripts
+                | install-scripts $pkg_dir (script-dir --ensure) --force  $force
             }
         },
         "script" => {
@@ -127,11 +125,7 @@ def install-path [
 
             $package.scripts?
             | default [ ($pkg_dir | path join $"($package.name).nu") ]
-            | if $force {
-                install-scripts --force $pkg_dir (script-dir --ensure)
-            } else {
-                install-scripts $pkg_dir (script-dir --ensure)
-            }
+            | install-scripts $pkg_dir (script-dir --ensure) --force  $force
         },
         "custom" => {
             let build_file = $pkg_dir | path join "build.nu"
@@ -176,9 +170,5 @@ export def main [
         throw-error "`nupm install` currently requires a `--path` flag"
     }
 
-    if $force {
-        install-path --force $name
-    } else {
-        install-path $name
-    }
+    install-path $name --force $force
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -61,7 +61,7 @@ def install-scripts [
     pkg_dir: path        # Package directory
     scripts_dir: path    # Target directory where to install
     --force(-f): bool    # Overwrite already installed scripts
-] {
+]: list<path> -> nothing {
     each {|script|
         let src_path = $pkg_dir | path join $script
         let tgt_path = $scripts_dir | path join $script
@@ -78,6 +78,8 @@ def install-scripts [
         log debug $"installing script `($src_path)` to `($scripts_dir)`"
         cp $src_path $scripts_dir
     }
+
+    null
 }
 
 # Install package from a directory containing 'project.nuon'

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -90,7 +90,6 @@ export def main [
     }
 
     let package = open-package-file $path
-    print $package
 
     log info $"installing package ($package.name)"
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -85,6 +85,8 @@ def install-scripts [path: path, package: record<scripts: list<path>>]: nothing 
 export def main [
     --path: path  # the path to the local source of the package (defaults to the current directory)
 ] {
+    nupm-home-prompt
+
     if $path == null {
         throw-error "`nupm install` requires a `--path`"
     }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -27,16 +27,28 @@ def open-package-file [dir: path] {
     let package_file = $dir | path join "package.nuon"
 
     if not ($package_file | path exists) {
-        throw-error $"package_file_not_found(ansi reset):\nno 'package.nuon' found in ($dir)"
+        throw-error (
+            [
+                $"package_file_not_found(ansi reset):"
+                $"no 'package.nuon' found in ($dir)"
+            ]
+            | str join (char nl))
     }
 
     let package = open $package_file
 
     log debug "checking package file for missing required keys"
     let required_keys = [$. $.name $.version $.type]
-    let missing_keys = $required_keys | where {|key| ($package | get -i $key) == null}
+    let missing_keys = $required_keys
+        | where {|key| ($package | get -i $key) == null}
     if not ($missing_keys | is-empty) {
-        throw-error $"invalid_package_file(ansi reset):\n($package_file) is missing the following required keys: ($missing_keys | str join ', ')"
+        throw-error (
+            [
+                $"invalid_package_file(ansi reset):"
+                ($"($package_file) is missing the following required keys:"
+                    + $" ($missing_keys | str join ', ')")
+            ]
+            | str join)
     }
 
     $package

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -168,7 +168,7 @@ export def main [
     name    # Name, path, or link to the package
     --path  # Install package from a directory with package.nuon given by 'name'
     --force(-f)  # Overwrite already installed package
-] {
+]: nothing -> nothing {
     nupm-home-prompt
 
     if not $path {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -48,7 +48,7 @@ def open-package-file [dir: path] {
                 ($"($package_file) is missing the following required keys:"
                     + $" ($missing_keys | str join ', ')")
             ]
-            | str join)
+            | str join (char nl))
     }
 
     $package

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,6 +1,6 @@
 use std log
 
-use utils/dirs.nu [ nupm-home-prompt script-dir module-dir ]
+use utils/dirs.nu [ nupm-home-prompt script-dir module-dir tmp-dir ]
 
 def throw-error [
     error: string
@@ -132,7 +132,13 @@ def install-path [
                     --span (metadata $pkg_dir | get span))
             }
 
+            let tmp_dir = tmp-dir build --ensure
+            cd $tmp_dir
+
             nu $build_file ($pkg_dir | path join 'package.nuon')
+
+            cd -
+            rm -rf $tmp_dir
         },
         _ => {
             let text = $"expected `$.type` to be one of [module, script,"

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,6 +1,6 @@
 use std log
 
-use utils/dirs.nu nupm-home-prompt
+use utils/dirs.nu [ nupm-home-prompt script-dir module-dir ]
 
 def throw-error [
     error: string
@@ -23,11 +23,11 @@ def throw-error [
     }
 }
 
-def open-package-file [path: path] {
-    let package_file = $path | path join "package.nuon"
+def open-package-file [dir: path] {
+    let package_file = $dir | path join "package.nuon"
 
     if not ($package_file | path exists) {
-        throw-error $"package_file_not_found(ansi reset):\nno 'package.nuon' found in ($path)"
+        throw-error $"package_file_not_found(ansi reset):\nno 'package.nuon' found in ($dir)"
     }
 
     let package = open $package_file
@@ -42,49 +42,105 @@ def open-package-file [path: path] {
     $package
 }
 
-def prepare-directory [directory: path] {
-    rm --recursive --force $directory
-    mkdir $directory
-}
+# Install list of scripts into a directory
+#
+# Input: Scripts taken from 'package.nuon'
+def install-scripts [
+    pkg_dir: path        # Package directory
+    scripts_dir: path    # Target directory where to install
+    --force(-f)          # Overwrite already installed scripts
+] {
+    each {|script|
+        let src_path = $pkg_dir | path join $script
+        let tgt_path = $scripts_dir | path join $script
 
-def copy-directory-to [destination: path] {
-    let source = $in
+        if ($src_path | path type) != file {
+            throw-error $"Script ($src_path) does not exist"
+        }
 
-    log info "copying directory"
-    log debug $"source: ($source)"
-    log debug $"destination: ($destination)"
+        if ($tgt_path | path type) == file and (not $force) {
+            throw-error ($"Script ($src_path) is already installed as"
+                + $" ($tgt_path)")
+        }
 
-    ls --all $source
-    | where {|it| not ($it.type == dir and ($it.name | path parse | get stem) == ".git")}
-    | each {|it|
-        log debug ($it.name | str replace $source "" | str trim --left --char (char path_sep))
-        cp --recursive $it.name $destination
+        log debug $"installing script `($src_path)` to `($scripts_dir)`"
+        cp $src_path $scripts_dir
     }
 }
 
-def install-scripts [path: path, package: record<scripts: list<path>>]: nothing -> nothing {
-    let nupm_bin = $env.NUPM_HOME | path join "bin"
-    mkdir $nupm_bin
+# Install package from a directory containing 'project.nuon'
+def install-path [
+    pkg_dir: path  # Directory (hopefully) containing 'package.nuon'
+    --force(-f)    # Overwrite already installed package
+] {
+    let pkg_dir = $pkg_dir | path expand --strict
 
-    for script in $package.scripts {
-        let script_path = $path | path join $script
-        let name = $script | path basename
-        let destination = $nupm_bin | path join $name
+    let package = open-package-file $pkg_dir
 
-        if ($script_path | path exists) {
-            log debug $"installing script `($name)` to `($destination)`"
-            cp $script_path $destination
-            chmod +x $destination
-        } else {
-            log warning $"($script_path) could not be found, skipping"
-        }
+    log info $"installing package ($package.name)"
+
+    match $package.type {
+        "module" => {
+            let mod_dir = $pkg_dir | path join $package.name
+
+            if ($mod_dir | path type) != dir {
+                throw-error ($"Module package '($package.name)' does not"
+                    + $" contain directory '($package.name)'")
+            }
+
+            let module_dir = module-dir --ensure
+            let destination = $module_dir | path join $package.name
+
+            if $force {
+                rm --recursive --force $destination
+            }
+
+            if ($destination | path type) == dir {
+                throw-error $"Package ($package.name) is already installed"
+            }
+
+            cp --recursive $mod_dir $module_dir
+
+            if $package.scripts? != null {
+                log debug $"installing scripts for package ($package.name)"
+                $package.scripts | if $force {
+                    install-scripts --force $pkg_dir (script-dir --ensure)
+                } else {
+                    install-scripts $pkg_dir (script-dir --ensure)
+                }
+            }
+        },
+        "script" => {
+            log debug $"installing scripts for package ($package.name)"
+
+            $package.scripts?
+            | default [ ($pkg_dir | path join $"($package.name).nu") ]
+            | if $force {
+                install-scripts --force $pkg_dir (script-dir --ensure)
+            } else {
+                install-scripts $pkg_dir (script-dir --ensure)
+            }
+        },
+        "custom" => {
+            if not ($pkg_dir | path join "build.nu" | path exists) {
+                let text = $"package uses a custom install but no `build.nu` has been found"
+                throw-error "invalid_package_file" $text --span (metadata $pkg_dir | get span)
+            }
+
+            nu ($pkg_dir | path join 'build.nu')
+        },
+        _ => {
+            let text = $"expected `$.type` to be one of [module, script, custom], got ($package.type)"
+            throw-error "invalid_package_file" $text --span (metadata $pkg_dir | get span)
+        },
     }
 }
 
 # Install a nupm package
 export def main [
     name    # Name, path, or link to the package
-    --path  # Install package from a path given by 'name'
+    --path  # Install package from a directory with package.nuon given by 'name'
+    --force(-f)  # Overwrite already installed package
 ] {
     nupm-home-prompt
 
@@ -92,41 +148,9 @@ export def main [
         throw-error "`nupm install` currently requires a `--path` flag"
     }
 
-    let package = open-package-file $name
-
-    log info $"installing package ($package.name)"
-
-    match $package.type {
-        "module" => {
-            let destination = $env.NUPM_HOME | path join $package.name
-
-            prepare-directory $destination
-            $name | copy-directory-to $destination
-
-            if $package.scripts? != null {
-                log debug $"installing scripts for package ($package.name)"
-                install-scripts $name $package
-            }
-        },
-        "script" => {
-            if "scripts" not-in $package {
-                let text = $"package is a script but does not have a `$.scripts` list"
-                throw-error "invalid_package_file" $text --span (metadata $name | get span)
-            }
-
-            install-scripts $name $package
-        },
-        "custom" => {
-            if not ($name | path join "build.nu" | path exists) {
-                let text = $"package uses a custom install but no `build.nu` has been found"
-                throw-error "invalid_package_file" $text --span (metadata $name | get span)
-            }
-
-            nu ($name | path join 'build.nu')
-        },
-        _ => {
-            let text = $"expected `$.type` to be one of [module, script, custom], got ($package.type)"
-            throw-error "invalid_package_file" $text --span (metadata $name | get span)
-        },
+    if $force {
+        install-path --force $name
+    } else {
+        install-path $name
     }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -122,16 +122,25 @@ def install-path [
             }
         },
         "custom" => {
-            if not ($pkg_dir | path join "build.nu" | path exists) {
-                let text = $"package uses a custom install but no `build.nu` has been found"
-                throw-error "invalid_package_file" $text --span (metadata $pkg_dir | get span)
+            let build_file = $pkg_dir | path join "build.nu"
+            if not ($build_file | path exists) {
+                let text = "package uses a custom install but no `build.nu` has"
+                        + " been found"
+                (throw-error
+                    "invalid_package_file"
+                    $text
+                    --span (metadata $pkg_dir | get span))
             }
 
-            nu ($pkg_dir | path join 'build.nu')
+            nu $build_file ($pkg_dir | path join 'package.nuon')
         },
         _ => {
-            let text = $"expected `$.type` to be one of [module, script, custom], got ($package.type)"
-            throw-error "invalid_package_file" $text --span (metadata $pkg_dir | get span)
+            let text = $"expected `$.type` to be one of [module, script,"
+                + " custom], got ($package.type)"
+            (throw-error
+                "invalid_package_file"
+                $text
+                --span (metadata $pkg_dir | get span))
         },
     }
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -132,8 +132,6 @@ def install-path [
             } else {
                 install-scripts $pkg_dir (script-dir --ensure)
             }
-
-            install-scripts $path $package
         },
         "custom" => {
             let build_file = $pkg_dir | path join "build.nu"

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,0 +1,13 @@
+use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
+
+export-env {
+    if 'NUPM_HOME' not-in $env {
+        $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
+    }
+}
+
+export def main [] {
+    nupm-home-prompt
+
+    print 'enjoy nupm!'
+}

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,9 +1,12 @@
-use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
+use utils/dirs.nu [ DEFAULT_NUPM_HOME DEFAULT_NUPM_TEMP nupm-home-prompt ]
 
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
     $env.NUPM_HOME = ($env.NUPM_HOME? | default $DEFAULT_NUPM_HOME)
+
+    # Ensure temporary path is set.
+    $env.NUPM_TEMP = ($env.NUPM_TEMP? | default $DEFAULT_NUPM_TEMP)
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,7 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    $env.NUPM_HOME = ($env.NUPM_HOME? | $DEFAULT_NUPM_HOME)
+    $env.NUPM_HOME = ($env.NUPM_HOME? | default $DEFAULT_NUPM_HOME)
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,9 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    if 'NUPM_HOME' not-in $env {
-        $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
-    }
+    $env.NUPM_HOME = $env.NUPM_HOME? | $DEFAULT_NUPM_HOME
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -3,7 +3,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
     # $env.NUPM_HOME during nupm execution is a bug.
-    $env.NUPM_HOME = $env.NUPM_HOME? | $DEFAULT_NUPM_HOME
+    $env.NUPM_HOME = ($env.NUPM_HOME? | $DEFAULT_NUPM_HOME)
 }
 
 # Nushell Package Manager

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -2,7 +2,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
-    # $env.NUPM_HOME is found during any nupm execution, it's a bug.
+    # $env.NUPM_HOME during nupm execution is a bug.
     if 'NUPM_HOME' not-in $env {
         $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
     }

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,11 +1,14 @@
 use utils/dirs.nu [ DEFAULT_NUPM_HOME nupm-home-prompt ]
 
 export-env {
+    # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing
+    # $env.NUPM_HOME is found during any nupm execution, it's a bug.
     if 'NUPM_HOME' not-in $env {
         $env.'NUPM_HOME' = $DEFAULT_NUPM_HOME
     }
 }
 
+# Nushell Package Manager
 export def main [] {
     nupm-home-prompt
 

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -10,7 +10,7 @@ export-env {
 }
 
 # Nushell Package Manager
-export def main [] {
+export def main []: nothing -> nothing {
     nupm-home-prompt
 
     print 'enjoy nupm!'

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -1,7 +1,10 @@
 # Directories and related utilities used in nupm
 
-# Decault installation path for nupm packages
+# Default installation path for nupm packages
 export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
+
+# Default temporary path for various nupm purposes
+export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 export def nupm-home-prompt [] {
@@ -50,6 +53,18 @@ export def script-dir [--ensure]: nothing -> path {
 
 export def module-dir [--ensure]: nothing -> path {
     let d = $env.NUPM_HOME | path join modules
+
+    if $ensure {
+        mkdir $d
+    }
+
+    $d
+}
+
+export def tmp-dir [subdir: string, --ensure] {
+    let d = $env.NUPM_TEMP
+        | path join $subdir
+        | path join (random chars -l 8)
 
     if $ensure {
         mkdir $d

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -37,3 +37,23 @@ export def nupm-home-prompt [] {
 
     mkdir $env.NUPM_HOME
 }
+
+export def script-dir [--ensure]: nothing -> path {
+    let d = $env.NUPM_HOME | path join scripts
+
+    if $ensure {
+        mkdir $d
+    }
+
+    $d
+}
+
+export def module-dir [--ensure]: nothing -> path {
+    let d = $env.NUPM_HOME | path join modules
+
+    if $ensure {
+        mkdir $d
+    }
+
+    $d
+}

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -61,7 +61,7 @@ export def module-dir [--ensure]: nothing -> path {
     $d
 }
 
-export def tmp-dir [subdir: string, --ensure] {
+export def tmp-dir [subdir: string, --ensure]: nothing -> path {
     let d = $env.NUPM_TEMP
         | path join $subdir
         | path join (random chars -l 8)

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -36,13 +36,4 @@ export def nupm-home-prompt [] {
     }
 
     mkdir $env.NUPM_HOME
-
-    let bin_dir = ($env.NUPM_HOME | path join bin)
-    let overlays_dir = ($env.NUPM_HOME | path join overlays)
-
-    mkdir $bin_dir
-    mkdir $overlays_dir
-
-    print ($"Don't forget to add ($bin_dir) to PATH/Path"
-        + $" and ($overlays_dir) to NU_LIB_DIRS environment variables!")
 }

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -1,0 +1,45 @@
+export const TMP_DIR = ($nu.temp-path | path join nupm)
+export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
+
+export def nupm-home-prompt [] {
+    if 'NUPM_HOME' not-in $env {
+        error make {
+            msg: "Internal error: NUPM_HOME environment variable is not set"
+        }
+    }
+
+    if ($env.NUPM_HOME | path exists) {
+        if ($env.NUPM_HOME | path type) != 'dir' {
+            error make {
+                msg: ($"Root directory ($env.NUPM_HOME) exists, but is not a"
+                    + "directory. Make sure $env.NUPM_HOME points at a valid"
+                    + "directory and try again.")
+            }
+        }
+
+        return
+    }
+
+    mut answer = ''
+
+    while ($answer | str downcase) not-in [ y n ] {
+        $answer = (input (
+            $'Root directory "($env.NUPM_HOME)" does not exist.'
+            + ' Do you want to create it? [y/n] '))
+    }
+
+    if ($answer | str downcase) != 'y' {
+        return
+    }
+
+    mkdir $env.NUPM_HOME
+
+    let bin_dir = ($env.NUPM_HOME | path join bin)
+    let overlays_dir = ($env.NUPM_HOME | path join overlays)
+
+    mkdir $bin_dir
+    mkdir $overlays_dir
+
+    print ($"Don't forget to add ($bin_dir) to PATH/Path"
+        + $" and ($overlays_dir) to NU_LIB_DIRS environment variables!")
+}

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -6,17 +6,17 @@ export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 export def nupm-home-prompt [] {
     if 'NUPM_HOME' not-in $env {
-        error make {
+        error make --unspanned {
             msg: "Internal error: NUPM_HOME environment variable is not set"
         }
     }
 
     if ($env.NUPM_HOME | path exists) {
         if ($env.NUPM_HOME | path type) != 'dir' {
-            error make {
+            error make --unspanned {
                 msg: ($"Root directory ($env.NUPM_HOME) exists, but is not a"
-                    + "directory. Make sure $env.NUPM_HOME points at a valid"
-                    + "directory and try again.")
+                    + " directory. Make sure $env.NUPM_HOME points at a valid"
+                    + " directory and try again.")
             }
         }
 

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -1,6 +1,9 @@
-export const TMP_DIR = ($nu.temp-path | path join nupm)
+# Directories and related utilities used in nupm
+
+# Decault installation path for nupm packages
 export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
 
+# Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 export def nupm-home-prompt [] {
     if 'NUPM_HOME' not-in $env {
         error make {


### PR DESCRIPTION
This PR mostly focuses on `nupm install` which got thoroughly refactored. See also notes in commit messages.

Approximate list of changes:
* Adds `nupm` command itself
* `$env.NUPM_HOME` is always set
* Adds a prompt to create `$env.NUPM_HOME` if it doesn't exist
* Moves directory handling to its own utils module
* Don't require description and license for `nupm install` (only necessary for publishing)
* Fixes module package to install only the module, not the entire project directory
* Module packages can have the "scripts" fields, just like script packages
* Format to fit 80 lines (Sorry! I don't handle too long lines well, as I tend to have multiple vertical windows open at the same time, I think the code looks more neat when it's on shorter lines.)
* Names the installation folders `scripts` and `modules`, depending on which type of project you're installing.
* Custom packages (with build.nu) are `cd`ed to a temporary directory as a "sandbox".
* Installing script package without "scripts" field will try to install `<package_name>.nu` by default.
* Other misc refactors?