### PR TITLE
export `throw-error` out of `log.nu`

### DIFF
--- a/nupm/utils/log.nu
+++ b/nupm/utils/log.nu
@@ -1,4 +1,4 @@
-def throw-error [
+export def throw-error [
     error: string
     text?: string
     --span: record<start: int, end: int>


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/pull/20

closes #21 

## description
i forgot to `export` the `throw-error` command out of `log.nu` in #20, my bad :eyes: 