### PR TITLE
throw a little error when there are failures

### DIFF
--- a/nupm/test.nu
+++ b/nupm/test.nu
@@ -77,4 +77,8 @@ export def main [
     print ($'Ran ($out | length) tests.'
         + $' ($successes | length) succeeded,'
         + $' ($failures | length) failed.')
+
+    if ($failures | length) != 0 {
+        error make --unspanned {msg: "some tests failed"}
+    }
 }


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/pull/26

## Description
after https://github.com/amtoine/nu-git-manager/pull/26, i would like to add `nupm test` to the CI :ok_hand: 

however, currently, `nupm test` does not return a true error when the tests fail and thus won't crash a CI :thinking: 

this PR throws a real error the number of `$failures` is non-zero :+1: 

## example
let's introduce an obvious error in the tests of `nupm` itself
```diff
diff --git a/tests/mod.nu b/tests/mod.nu
index b20e9bc..7d0fbac 100644
--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -22,6 +22,8 @@ export def install-script [] {
             | path join
             | path exists)
     }
+
+    assert false
 }
 
 export def install-module [] {
```

running `nupm test; print "all tests passed"` should not print the string
- before the changes: it did
```
Testing package /home/amtoine/documents/repos/github.com/amtoine/nupm
tests install-module ... SUCCESS
tests install-script ... FAILURE
tests install-custom ... SUCCESS

Test "tests install-script" failed with exit code 1:
2023-10-10T19:10:54.072|INF|installing package spam_script
Error:   × Assertion failed.
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nupm/tests/mod.nu:25:1]
 25 │
 26 │     assert false
    ·            ──┬──
    ·              ╰── It is not true.
 27 │ }
    ╰────

Ran 3 tests. 2 succeeded, 1 failed.
all test passed
```
- after the changes: it does not anymore
```
Testing package /home/amtoine/documents/repos/github.com/amtoine/nupm
tests install-module ... SUCCESS
tests install-script ... FAILURE
tests install-custom ... SUCCESS

Test "tests install-script" failed with exit code 1:
2023-10-10T19:10:59.395|INF|installing package spam_script
Error:   × Assertion failed.
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nupm/tests/mod.nu:25:1]
 25 │
 26 │     assert false
    ·            ──┬──
    ·              ╰── It is not true.
 27 │ }
    ╰────

Ran 3 tests. 2 succeeded, 1 failed.
Error:   × some tests failed
```
