### PR TITLE
add a CI to run the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+name: continuous-integration
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-20.04]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
+
+      - name: Install Nushell
+        run: cargo install --locked --git https://github.com/nushell/nushell.git nu
+
+      - name: Run the tests
+        run: nu --commands "use $PWD/nupm/; nupm test"


### PR DESCRIPTION
## Description
in this PR, i add a simple CI to Nupm which
- runs on all of our three major platforms
- runs on PRs (just not this one lol) and on the `main` branch
- installs Rust and Cargo
- installs Nushell with `cargo` from Git to have the latest at all time
- run the tests

please see [this action](https://github.com/amtoine/nushell-nupm/actions/runs/6486011138) for the results :pray: 