### PR TITLE
add support to install modules from non standard locations

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -74,7 +74,7 @@ def install-path [
 
     match $package.type {
         "module" => {
-            let mod_dir = $pkg_dir | path join $package.name
+            let mod_dir = $pkg_dir | path join ($package.root? | default $package.name) | path expand
 
             if ($mod_dir | path type) != dir {
                 throw-error "invalid_module_package" (
@@ -97,7 +97,7 @@ def install-path [
                 )
             }
 
-            cp --recursive $mod_dir $module_dir
+            cp --recursive $mod_dir $destination
 
             if $package.scripts? != null {
                 log debug $"installing scripts for package ($package.name)"

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -36,6 +36,24 @@ export def install-module [] {
     }
 }
 
+export def install-module-with-repo-root [] {
+    with-nupm-home {
+        nupm install --path tests/packages/spam_module_repo_root
+
+        assert (check-install [modules spam_module_repo_root])
+        assert (check-install [modules spam_module_repo_root mod.nu])
+    }
+}
+
+export def install-module-with-src-root [] {
+    with-nupm-home {
+        nupm install --path tests/packages/spam_module_src_root
+
+        assert (check-install [modules spam_module_src_root])
+        assert (check-install [modules spam_module_src_root mod.nu])
+    }
+}
+
 export def install-custom [] {
     with-nupm-home {
         nupm install --path tests/packages/spam_custom

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -10,17 +10,20 @@ def with-nupm-home [closure: closure]: nothing -> nothing {
     rm -r $dir
 }
 
+# Examples:
+#     make sure `$env.NUPM_HOME/scripts/script.nu` exists
+#     > assert (check-install [scripts script.nu])
+def check-install [path_tokens: list<string>] {
+    $path_tokens | prepend $env.NUPM_HOME | path join | path exists
+}
+
 export def install-script [] {
     with-nupm-home {
         cd tests/packages/spam_script
 
         nupm install --path .
-        assert ([$env.NUPM_HOME scripts spam_script.nu]
-            | path join
-            | path exists)
-        assert ([$env.NUPM_HOME scripts spam_bar.nu]
-            | path join
-            | path exists)
+        assert (check-install [scripts spam_script.nu])
+        assert (check-install [scripts spam_bar.nu])
     }
 }
 
@@ -29,11 +32,9 @@ export def install-module [] {
         cd tests/packages/spam_module
 
         nupm install --path .
-        assert ([$env.NUPM_HOME scripts script.nu] | path join | path exists)
-        assert ([$env.NUPM_HOME modules spam_module] | path join | path exists)
-        assert ([$env.NUPM_HOME modules spam_module mod.nu]
-            | path join
-            | path exists)
+        assert (check-install [scripts script.nu])
+        assert (check-install [modules spam_module])
+        assert (check-install [modules spam_module mod.nu])
     }
 }
 
@@ -42,8 +43,6 @@ export def install-custom [] {
         cd tests/packages/spam_custom
 
         nupm install --path .
-        assert ([$env.NUPM_HOME plugins nu_plugin_test]
-            | path join
-            | path exists)
+        assert (check-install [plugins nu_plugin_test])
     }
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -19,9 +19,8 @@ def check-install [path_tokens: list<string>] {
 
 export def install-script [] {
     with-nupm-home {
-        cd tests/packages/spam_script
+        nupm install --path tests/packages/spam_script
 
-        nupm install --path .
         assert (check-install [scripts spam_script.nu])
         assert (check-install [scripts spam_bar.nu])
     }
@@ -29,9 +28,8 @@ export def install-script [] {
 
 export def install-module [] {
     with-nupm-home {
-        cd tests/packages/spam_module
+        nupm install --path tests/packages/spam_module
 
-        nupm install --path .
         assert (check-install [scripts script.nu])
         assert (check-install [modules spam_module])
         assert (check-install [modules spam_module mod.nu])
@@ -40,9 +38,8 @@ export def install-module [] {
 
 export def install-custom [] {
     with-nupm-home {
-        cd tests/packages/spam_custom
+        nupm install --path tests/packages/spam_custom
 
-        nupm install --path .
         assert (check-install [plugins nu_plugin_test])
     }
 }

--- a/tests/packages/spam_module_repo_root/mod.nu
+++ b/tests/packages/spam_module_repo_root/mod.nu
@@ -1,0 +1,3 @@
+export def main [] {
+    "Hello world!"
+}

--- a/tests/packages/spam_module_repo_root/package.nuon
+++ b/tests/packages/spam_module_repo_root/package.nuon
@@ -1,0 +1,6 @@
+{
+    name: spam_module_repo_root,
+    type: module,
+    version: "0.1.0"
+    root: "./"
+}

--- a/tests/packages/spam_module_src_root/package.nuon
+++ b/tests/packages/spam_module_src_root/package.nuon
@@ -1,0 +1,6 @@
+{
+    name: spam_module_src_root,
+    type: module,
+    version: "0.1.0"
+    root: "./src/"
+}

--- a/tests/packages/spam_module_src_root/src/mod.nu
+++ b/tests/packages/spam_module_src_root/src/mod.nu
@@ -1,0 +1,3 @@
+export def main [] {
+    "Hello world!"
+}


### PR DESCRIPTION
## Description
- refactors a bit the tests to make them easier to work with in the long run
- adds two tests to
  1. install from `src/`: `spam_module_src_root` module and `install-module-with-src-root` test
  2. install from the root of the repo: `spam_module_repo_root` module and `install-module-with-repo-root` test
- allows to change the path to the package module files with `$.root` in the `package.nuon` file

the general idea is that
- if `$.root` is not defined, `nupm install` will try to install the module files from the subdirectory inside the root whose called the same as the package, e.g. `nu-git-manager` would install from `./nu-git-manager/`
- if `$.root` is defined, `nupm install` will copy the files from `$.root` and put that in the same place in the Nupm store