### PR TITLE
CI: install Nushell from latest nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
           cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
 
       - name: Show Nushell Version
-        run: "$HOME/${{ env.NU_BIN }}" --commands "version"
+        run: |
+            "$HOME/${{ env.NU_BIN }}" --commands "version"
 
       - name: Run the tests
-        run: "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"
+        run: |
+            "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
 
 name: continuous-integration
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   tests:
     strategy:
@@ -18,19 +22,40 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set platform-specific variables
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            echo "ARCH=x86_64-linux-gnu-full" >> $GITHUB_ENV
+            echo "EXT=tar.gz" >> $GITHUB_ENV
+            echo "NU_BIN=nu" >> $GITHUB_ENV
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            echo "ARCH=x86_64-pc-windows-msvc" >> $GITHUB_ENV
+            echo "EXT=zip" >> $GITHUB_ENV
+            echo "NU_BIN=nu.exe" >> $GITHUB_ENV
+          elif [ "${{ runner.os }}" = "macOS" ]; then
+            echo "ARCH=x86_64-apple-darwin" >> $GITHUB_ENV
+            echo "EXT=tar.gz" >> $GITHUB_ENV
+            echo "NU_BIN=nu" >> $GITHUB_ENV
+          fi
+
       - name: Install Nushell from Nightly
         run: |
           tarball=$(\
             curl -L https://api.github.com/repos/nushell/nightly/releases \
                 | jq 'sort_by(.published_at) | reverse | .[0].assets'\
-                | jq '.[] | select(.name | test("x86_64-linux-gnu-full.tar.gz")) | {name, browser_download_url}'\
+                | jq '.[] | select(.name | test("${{ env.ARCH }}.${{ env.EXT }}")) | {name, browser_download_url}'\
             )
-          name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.tar.gz$//')
+          name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.${{ env.EXT }}$//')
           url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
 
           curl -fLo $name $url
-          tar xvf $name --directory /tmp
-          cp /tmp/$name/nu $HOME/nu
+
+          if [ "${{ env.EXT }}" = "tar.gz" ]; then
+            tar xvf $name --directory /tmp
+          elif [ "${{ env.EXT }}" = "zip" ]; then
+            unzip $name -d "/tmp/$name"
+          fi
+          cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
 
       - name: Run the tests
-        run: $HOME/nu --commands "use $PWD/nupm/; nupm test"
+        run: "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,11 @@ jobs:
 
       - name: Run the tests
         run: |
+          # NOTE: for some reason, `$PWD` gives an incorrect path on Windows
+          # it looks like `/d/a/nupm/nupm` where it should really be `d:\a\nupm\nupm`
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # NOTE: this commands changes the `/` into `\` and replaces the first one with a ":"
+            "$HOME/${{ env.NU_BIN }}" --commands "use $(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')/nupm/; nupm test"
+          else
             "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
-        with:
-          rustflags: ""
+      - name: Install Nushell from Nightly
+        run: |
+          tarball=$(curl -L https://api.github.com/repos/nushell/nightly/releases | jq 'sort_by(.published_at) | reverse | .[0].assets' | jq '.[] | select(.name | test("x86_64-linux-gnu-full.tar.gz")) | {name, browser_download_url}')
+          name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.tar.gz$//')
+          url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
 
-      - name: Install Nushell
-        run: cargo install --locked --git https://github.com/nushell/nushell.git nu
+          curl -fLo $name $url
+          tar xvf $name --directory /tmp
+          cp /tmp/$name/nu $HOME/nu
 
       - name: Run the tests
-        run: nu --commands "use $PWD/nupm/; nupm test"
+        run: $HOME/nu --commands "use $PWD/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ jobs:
 
       - name: Install Nushell from Nightly
         run: |
-          tarball=$(curl -L https://api.github.com/repos/nushell/nightly/releases | jq 'sort_by(.published_at) | reverse | .[0].assets' | jq '.[] | select(.name | test("x86_64-linux-gnu-full.tar.gz")) | {name, browser_download_url}')
+          tarball=$(\
+            curl -L https://api.github.com/repos/nushell/nightly/releases \
+                | jq 'sort_by(.published_at) | reverse | .[0].assets'\
+                | jq '.[] | select(.name | test("x86_64-linux-gnu-full.tar.gz")) | {name, browser_download_url}'\
+            )
           name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.tar.gz$//')
           url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,8 @@ jobs:
           fi
           cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
 
+      - name: Show Nushell Version
+        run: "$HOME/${{ env.NU_BIN }}" --commands "version"
+
       - name: Run the tests
         run: "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: continuous-integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,20 @@ jobs:
             echo "ARCH=x86_64-linux-gnu-full" >> $GITHUB_ENV
             echo "EXT=tar.gz" >> $GITHUB_ENV
             echo "NU_BIN=nu" >> $GITHUB_ENV
+            echo "CWD=$PWD" >> $GITHUB_ENV
           elif [ "${{ runner.os }}" = "Windows" ]; then
             echo "ARCH=x86_64-pc-windows-msvc" >> $GITHUB_ENV
             echo "EXT=zip" >> $GITHUB_ENV
             echo "NU_BIN=nu.exe" >> $GITHUB_ENV
+            # NOTE: for some reason, `$PWD` gives an incorrect path on Windows, e.g. it looks like
+            # `/d/a/nupm/nupm` where it should really be `d:\a\nupm\nupm`: this commands changes the
+            # `/` into `\` and replaces the first part of the path with "x:\"
+            echo "CWD=$(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')" >> $GITHUB_ENV
           elif [ "${{ runner.os }}" = "macOS" ]; then
             echo "ARCH=x86_64-apple-darwin" >> $GITHUB_ENV
             echo "EXT=tar.gz" >> $GITHUB_ENV
             echo "NU_BIN=nu" >> $GITHUB_ENV
+            echo "CWD=$PWD" >> $GITHUB_ENV
           fi
 
       - name: Install Nushell from Nightly
@@ -60,15 +66,8 @@ jobs:
 
       - name: Show Nushell Version
         run: |
-            "$HOME/${{ env.NU_BIN }}" --commands "version"
+          "$HOME/${{ env.NU_BIN }}" --commands "version"
 
       - name: Run the tests
         run: |
-          # NOTE: for some reason, `$PWD` gives an incorrect path on Windows
-          # it looks like `/d/a/nupm/nupm` where it should really be `d:\a\nupm\nupm`
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            # NOTE: this commands changes the `/` into `\` and replaces the first one with a ":"
-            "$HOME/${{ env.NU_BIN }}" --commands "use $(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')/nupm/; nupm test"
-          else
-            "$HOME/${{ env.NU_BIN }}" --commands "use $PWD/nupm/; nupm test"
-          fi
+          "$HOME/${{ env.NU_BIN }}" --commands "use ${{ env.CWD }}/nupm/; nupm test"

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -128,7 +128,7 @@ def install-path [
 
             do {
                 cd $tmp_dir
-                nu $build_file ($pkg_dir | path join 'package.nuon')
+                ^$nu.current-exe $build_file ($pkg_dir | path join 'package.nuon')
             }
 
             rm -rf $tmp_dir

--- a/nupm/test.nu
+++ b/nupm/test.nu
@@ -18,7 +18,7 @@ export def main [
     print $'Testing package ($pkg_root)'
     cd $pkg_root
 
-    let tests = nu [
+    let tests = ^$nu.current-exe [
         --no-config-file
         --commands
         'use tests/
@@ -34,7 +34,7 @@ export def main [
         | where ($filter in $it)
         | par-each {|test|
             let res = do {
-                nu [
+                ^$nu.current-exe [
                     --no-config-file
                     --commands
                     $'use tests/; ($test)'


### PR DESCRIPTION
related to
- #29 

should close #29 

## Description
this PR uses the nightly builds of Nushell to save download + compilation time. The CI goes
from
- 9, 10 and 16 seconds for MacOS, Linux and Windows respectively (see the [CI on the `main` branch](https://github.com/nushell/nupm/actions/runs/6486862219))
- 7min23, 7min32 and 12min25 for MacOS, Linux and Windows respectively (see the [CI on this PR branch](https://github.com/nushell/nupm/actions/runs/6496461672))

## Changelog
this PR uses `$nu.current-exe` instead of implicite `nu` in `nupm install` and `nupm test`: this allows to not rely on `nu` being in the `PATH`, e.g. inside `$HOME/` in the CI

the CI
- does not install Rust and Cargo anymore
- pulls the latest asset with `curl` and `jq`
- uses different architecture and archive tool per platform
- extracts the archive to `$HOME/nu`
- shows the version of Nushell
- can run on *workflow dispatch*, i.e. manually

> **Note**
> there is a trick to run `use nupm` on Windows...
> see the *Run the tests* step, the goal being to avoid [that kind of error](https://github.com/nushell/nupm/actions/runs/6494023016/job/17636126381)