### PR TITLE
give better error when tests/ not found

### DIFF
--- a/nupm/test.nu
+++ b/nupm/test.nu
@@ -11,8 +11,9 @@ export def main [
     let pkg_root = find-root $dir
 
     if $pkg_root == null {
-        throw-error ($'Could not find "package.nuon" in ($dir)'
-            + ' or any parent directory.')
+        throw-error "package_file_not_found" (
+            $'Could not find "package.nuon" in ($dir) or any parent directory.'
+        )
     }
 
     if ($pkg_root | path join "tests" | path type) != "dir" {

--- a/nupm/test.nu
+++ b/nupm/test.nu
@@ -15,6 +15,18 @@ export def main [
             + ' or any parent directory.')
     }
 
+    if ($pkg_root | path join "tests" | path type) != "dir" {
+        throw-error "test_directory_not_found" (
+            $"tests/ directory module not found for in ($pkg_root)"
+        )
+    }
+
+    if ($pkg_root | path join "tests" "mod.nu" | path type) != "file" {
+        throw-error "invalid_test_directory" (
+            $"tests/ directory module in ($pkg_root) is missing a `mod.nu`"
+        )
+    }
+
     print $'Testing package ($pkg_root)'
     cd $pkg_root
 


### PR DESCRIPTION
> **Note**
> should add a check for the existence of the `tests/` directory module

_Originally posted by @amtoine in https://github.com/nushell/nupm/pull/19#discussion_r1344431040_

## Description
it appears i've also missed a bad error format in my https://github.com/nushell/nupm/pull/20, so here it is :wink: 

the main goal of this PR is to make the error when `tests/` or `/tests/mod.nu` are missing :yum: 