### PR TITLE
refactor the tests

### DIFF
--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -12,17 +12,17 @@ def with-nupm-home [closure: closure]: nothing -> nothing {
 
 # Examples:
 #     make sure `$env.NUPM_HOME/scripts/script.nu` exists
-#     > assert (check-install [scripts script.nu])
-def check-install [path_tokens: list<string>] {
-    $path_tokens | prepend $env.NUPM_HOME | path join | path exists
+#     > assert installed [scripts script.nu]
+def "assert installed" [path_tokens: list<string>] {
+    assert ($path_tokens | prepend $env.NUPM_HOME | path join | path exists)
 }
 
 export def install-script [] {
     with-nupm-home {
         nupm install --path tests/packages/spam_script
 
-        assert (check-install [scripts spam_script.nu])
-        assert (check-install [scripts spam_bar.nu])
+        assert installed [scripts spam_script.nu]
+        assert installed [scripts spam_bar.nu]
     }
 }
 
@@ -30,9 +30,9 @@ export def install-module [] {
     with-nupm-home {
         nupm install --path tests/packages/spam_module
 
-        assert (check-install [scripts script.nu])
-        assert (check-install [modules spam_module])
-        assert (check-install [modules spam_module mod.nu])
+        assert installed [scripts script.nu]
+        assert installed [modules spam_module]
+        assert installed [modules spam_module mod.nu]
     }
 }
 
@@ -40,8 +40,8 @@ export def install-module-nodefault [] {
     with-nupm-home {
         nupm install --path tests/packages/spam_module_nodefault
 
-        assert (check-install [modules nodefault ])
-        assert (check-install [modules nodefault mod.nu])
+        assert installed [modules nodefault ]
+        assert installed [modules nodefault mod.nu]
     }
 }
 
@@ -49,6 +49,6 @@ export def install-custom [] {
     with-nupm-home {
         nupm install --path tests/packages/spam_custom
 
-        assert (check-install [plugins nu_plugin_test])
+        assert installed [plugins nu_plugin_test]
     }
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -7,7 +7,7 @@ use ../nupm
 def with-nupm-home [closure: closure]: nothing -> nothing {
     let dir = tmp-dir test --ensure
     with-env { NUPM_HOME: $dir } $closure
-    rm -r $dir
+    rm --recursive $dir
 }
 
 # Examples:

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -10,17 +10,20 @@ def with-nupm-home [closure: closure]: nothing -> nothing {
     rm -r $dir
 }
 
+# Examples:
+#     make sure `$env.NUPM_HOME/scripts/script.nu` exists
+#     > assert (check-install [scripts script.nu])
+def check-install [path_tokens: list<string>] {
+    $path_tokens | prepend $env.NUPM_HOME | path join | path exists
+}
+
 export def install-script [] {
     with-nupm-home {
         cd tests/packages/spam_script
 
         nupm install --path .
-        assert ([$env.NUPM_HOME scripts spam_script.nu]
-            | path join
-            | path exists)
-        assert ([$env.NUPM_HOME scripts spam_bar.nu]
-            | path join
-            | path exists)
+        assert (check-install [scripts spam_script.nu])
+        assert (check-install [scripts spam_bar.nu])
     }
 }
 
@@ -29,11 +32,9 @@ export def install-module [] {
         cd tests/packages/spam_module
 
         nupm install --path .
-        assert ([$env.NUPM_HOME scripts script.nu] | path join | path exists)
-        assert ([$env.NUPM_HOME modules spam_module] | path join | path exists)
-        assert ([$env.NUPM_HOME modules spam_module mod.nu]
-            | path join
-            | path exists)
+        assert (check-install [scripts script.nu])
+        assert (check-install [modules spam_module])
+        assert (check-install [modules spam_module mod.nu])
     }
 }
 
@@ -42,10 +43,8 @@ export def install-module-nodefault [] {
         cd tests/packages/spam_module_nodefault
 
         nupm install --path .
-        assert ([$env.NUPM_HOME modules nodefault ] | path join | path exists)
-        assert ([$env.NUPM_HOME modules nodefault mod.nu]
-            | path join
-            | path exists)
+        assert (check-install [modules nodefault ])
+        assert (check-install [modules nodefault mod.nu])
     }
 }
 
@@ -54,8 +53,6 @@ export def install-custom [] {
         cd tests/packages/spam_custom
 
         nupm install --path .
-        assert ([$env.NUPM_HOME plugins nu_plugin_test]
-            | path join
-            | path exists)
+        assert (check-install [plugins nu_plugin_test])
     }
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -19,9 +19,8 @@ def check-install [path_tokens: list<string>] {
 
 export def install-script [] {
     with-nupm-home {
-        cd tests/packages/spam_script
+        nupm install --path tests/packages/spam_script
 
-        nupm install --path .
         assert (check-install [scripts spam_script.nu])
         assert (check-install [scripts spam_bar.nu])
     }
@@ -29,9 +28,8 @@ export def install-script [] {
 
 export def install-module [] {
     with-nupm-home {
-        cd tests/packages/spam_module
+        nupm install --path tests/packages/spam_module
 
-        nupm install --path .
         assert (check-install [scripts script.nu])
         assert (check-install [modules spam_module])
         assert (check-install [modules spam_module mod.nu])
@@ -40,9 +38,8 @@ export def install-module [] {
 
 export def install-module-nodefault [] {
     with-nupm-home {
-        cd tests/packages/spam_module_nodefault
+        nupm install --path tests/packages/spam_module_nodefault
 
-        nupm install --path .
         assert (check-install [modules nodefault ])
         assert (check-install [modules nodefault mod.nu])
     }
@@ -50,9 +47,8 @@ export def install-module-nodefault [] {
 
 export def install-custom [] {
     with-nupm-home {
-        cd tests/packages/spam_custom
+        nupm install --path tests/packages/spam_custom
 
-        nupm install --path .
         assert (check-install [plugins nu_plugin_test])
     }
 }


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/pull/28

## Description
https://github.com/nushell/nupm/pull/28 has been superseded by https://github.com/nushell/nupm/pull/33 but we agreed with @kubouch in [this discussion](https://discord.com/channels/601130461678272522/1112829613920505956/1164448758784868383) to keep the refactoring of the tests that was part of the original PR.

this very PR cherry-picks these changes and refactors the tests with a new `assert installed` command.
the changes also use `nupm install --path /path/to/package` instead of `cd /path/to/package; nupm install --path .`: it's the same but i feel it's more direct without the `cd` :yum: 