### PR TITLE
use the last path token as destination for install

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -72,7 +72,7 @@ def install-modules [
 ]: list<path> -> nothing {
     each {|module|
         let src_path = $pkg_dir | path join $module
-        let dst_path = $modules_dir | path join $module
+        let dst_path = $modules_dir | path join ($module | path split | last)
 
         if not ($src_path | path exists) {
             throw-error "module_not_found" $"Module ($src_path) does not exist"


### PR DESCRIPTION
related to 
- https://github.com/nushell/nu_scripts/pull/648#issuecomment-1773920283

## Description
when trying to make the themes of the `nu_scripts` a module that can be installed as part of the `nu-scripts` package in https://github.com/nushell/nu_scripts/pull/648, there is a big issue: all the files in the themes directory are installed, this includes the themes but also a README, script, and 55Mb of screenshots :thinking: 

in this PR i try to mitigate that issue with a simple change :yum: 

instead of installing the themes from `nu-themes/` with `./nu-themes/` in `$.modules` in `package.nuon`
```
#┬────────name─────────┬type
0│nu-themes/README.md  │file
1│nu-themes/make.nu    │file
2│nu-themes/screenshots│dir
3│nu-themes/themes     │dir
─┴─────────────────────┴────
```
which will install the screenshots, this PR allows to install only the `nu-themes/` directory in a `themes/` directory, i.e. swap the names of the two directories
```
#┬───────name───────┬type
0│themes/README.md  │file
1│themes/make.nu    │file
2│themes/nu-themes  │dir
3│themes/screenshots│dir
─┴──────────────────┴────
```
and then specifying `$.modules` as being `[./themes/nu-themes]` :exclamation: 

the only change is that the destination for the package is computed as the last path token from `$.modules`, here `nu-themes` :ok_hand: 