### PR TITLE
fix the logic of checking module destination

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -82,7 +82,7 @@ def install-modules [
             rm --recursive --force $dst_path
         }
 
-        if ($dst_path | path exists) == file and (not $force) {
+        if ($dst_path | path exists) and (not $force) {
             throw-error "module_already_installed" (
                 $"Module  ($src_path) is already installed in"
                 + $" ($modules_dir). Use `--force` to override it."


### PR DESCRIPTION
## Description
i'm not sure `(... | path exists) == file` is doing anything very interesting, right? :open_mouth: 

`(... | path exists)` or `(... | path type) == file` sounds more legit to me, i went with the former given the context of the command it's used in: it's checking for the existence :yum: 