### PR TITLE
refactor the CI into workflow scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set platform-specific variables
-        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh "${{ runner.os }}" "$GITHUB_ENV"
+        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh "${{ runner.os }}" >> "$GITHUB_ENV"
 
       - name: Install Nushell from Nightly
         run: bash $CI_SCRIPTS/install-nightly-nushell.sh "${{ env.ARCH }}" "${{ env.EXT }}" "${{ env.NU_BIN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  CI_SCRIPTS: "./github/workflows/scripts"
+
 jobs:
   tests:
     strategy:
@@ -24,45 +27,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set platform-specific variables
-        run: |
-          if [ "${{ runner.os }}" = "Linux" ]; then
-            echo "ARCH=x86_64-linux-gnu-full" >> $GITHUB_ENV
-            echo "EXT=tar.gz" >> $GITHUB_ENV
-            echo "NU_BIN=nu" >> $GITHUB_ENV
-            echo "CWD=$PWD" >> $GITHUB_ENV
-          elif [ "${{ runner.os }}" = "Windows" ]; then
-            echo "ARCH=x86_64-pc-windows-msvc" >> $GITHUB_ENV
-            echo "EXT=zip" >> $GITHUB_ENV
-            echo "NU_BIN=nu.exe" >> $GITHUB_ENV
-            # NOTE: for some reason, `$PWD` gives an incorrect path on Windows, e.g. it looks like
-            # `/d/a/nupm/nupm` where it should really be `d:\a\nupm\nupm`: this commands changes the
-            # `/` into `\` and replaces the first part of the path with "x:\"
-            echo "CWD=$(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')" >> $GITHUB_ENV
-          elif [ "${{ runner.os }}" = "macOS" ]; then
-            echo "ARCH=x86_64-apple-darwin" >> $GITHUB_ENV
-            echo "EXT=tar.gz" >> $GITHUB_ENV
-            echo "NU_BIN=nu" >> $GITHUB_ENV
-            echo "CWD=$PWD" >> $GITHUB_ENV
-          fi
+        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh
 
       - name: Install Nushell from Nightly
-        run: |
-          tarball=$(\
-            curl -L https://api.github.com/repos/nushell/nightly/releases \
-                | jq 'sort_by(.published_at) | reverse | .[0].assets'\
-                | jq '.[] | select(.name | test("${{ env.ARCH }}.${{ env.EXT }}")) | {name, browser_download_url}'\
-            )
-          name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.${{ env.EXT }}$//')
-          url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
-
-          curl -fLo $name $url
-
-          if [ "${{ env.EXT }}" = "tar.gz" ]; then
-            tar xvf $name --directory /tmp
-          elif [ "${{ env.EXT }}" = "zip" ]; then
-            unzip $name -d "/tmp/$name"
-          fi
-          cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
+        run: bash $CI_SCRIPTS/install-nightly-nushell.sh
 
       - name: Show Nushell Version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ defaults:
     shell: bash
 
 env:
-  CI_SCRIPTS: "./github/workflows/scripts"
+  CI_SCRIPTS: ".github/workflows/scripts"
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash $CI_SCRIPTS/set-platform-specific-variables.sh "${{ runner.os }}" "$GITHUB_ENV"
 
       - name: Install Nushell from Nightly
-        run: bash $CI_SCRIPTS/install-nightly-nushell.sh
+        run: bash $CI_SCRIPTS/install-nightly-nushell.sh "${{ env.ARCH }}" "${{ env.EXT }}" "${{ env.NU_BIN }}"
 
       - name: Show Nushell Version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set platform-specific variables
-        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh
+        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh "${{ runner.os }}" "$GITHUB_ENV"
 
       - name: Install Nushell from Nightly
         run: bash $CI_SCRIPTS/install-nightly-nushell.sh

--- a/.github/workflows/scripts/install-nightly-nushell.sh
+++ b/.github/workflows/scripts/install-nightly-nushell.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+tarball=$(\
+    curl -L https://api.github.com/repos/nushell/nightly/releases \
+        | jq 'sort_by(.published_at) | reverse | .[0].assets'\
+        | jq '.[] | select(.name | test("${{ env.ARCH }}.${{ env.EXT }}")) | {name, browser_download_url}'\
+)
+name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.${{ env.EXT }}$//')
+url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
+
+curl -fLo $name $url
+
+if [ "${{ env.EXT }}" = "tar.gz" ]; then
+    tar xvf $name --directory /tmp
+elif [ "${{ env.EXT }}" = "zip" ]; then
+    unzip $name -d "/tmp/$name"
+fi
+cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"

--- a/.github/workflows/scripts/install-nightly-nushell.sh
+++ b/.github/workflows/scripts/install-nightly-nushell.sh
@@ -7,9 +7,9 @@ nu="$3"
 tarball=$(\
     curl -L https://api.github.com/repos/nushell/nightly/releases \
         | jq 'sort_by(.published_at) | reverse | .[0].assets'\
-        | jq '.[] | select(.name | test("$arch.$ext")) | {name, browser_download_url}'\
+        | jq ".[] | select(.name | test(\"$arch.$ext\")) | {name, browser_download_url}"\
 )
-name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.$ext$//')
+name=$(echo $tarball | jq '.name' | tr -d '"' | sed "s/.$ext$//")
 url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
 
 curl -fLo $name $url

--- a/.github/workflows/scripts/install-nightly-nushell.sh
+++ b/.github/workflows/scripts/install-nightly-nushell.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 
+arch="$1"
+ext="$2"
+nu="$3"
+
 tarball=$(\
     curl -L https://api.github.com/repos/nushell/nightly/releases \
         | jq 'sort_by(.published_at) | reverse | .[0].assets'\
-        | jq '.[] | select(.name | test("${{ env.ARCH }}.${{ env.EXT }}")) | {name, browser_download_url}'\
+        | jq '.[] | select(.name | test("$arch.$ext")) | {name, browser_download_url}'\
 )
-name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.${{ env.EXT }}$//')
+name=$(echo $tarball | jq '.name' | tr -d '"' | sed 's/.$ext$//')
 url=$(echo $tarball | jq '.browser_download_url' | tr -d '"')
 
 curl -fLo $name $url
 
-if [ "${{ env.EXT }}" = "tar.gz" ]; then
+if [ "$ext" = "tar.gz" ]; then
     tar xvf $name --directory /tmp
-elif [ "${{ env.EXT }}" = "zip" ]; then
+elif [ "$ext" = "zip" ]; then
     unzip $name -d "/tmp/$name"
 fi
-cp "/tmp/$name/${{ env.NU_BIN }}" "$HOME/${{ env.NU_BIN }}"
+cp "/tmp/$name/$nu" "$HOME/$nu"

--- a/.github/workflows/scripts/set-platform-specific-variables.sh
+++ b/.github/workflows/scripts/set-platform-specific-variables.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+os="$1"
+github_env="${2:-$GITHUB_ENV}"
+
+function save-env () {
+    sed 's/^\s*//' >> $github_env
+}
+
+if [ "$os" = "Linux" ]; then
+    echo "
+        ARCH=x86_64-linux-gnu-full
+        EXT=tar.gz
+        NU_BIN=nu
+        NUPM=$HOME/nupm
+        CWD=$HOME
+    " | save-env
+elif [ "$os" = "Windows" ]; then
+    echo "
+        ARCH=x86_64-pc-windows-msvc
+        EXT=zip
+        NU_BIN=nu.exe
+        NUPM=$(echo $HOME | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')/nupm
+        CWD=$(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')
+    " | save-env
+elif [ "$os" = "macOS" ]; then
+    echo "
+        ARCH=x86_64-apple-darwin
+        EXT=tar.gz
+        NU_BIN=nu
+        NUPM=$HOME/nupm
+        CWD=$HOME
+    " | save-env
+else
+    echo "UNKNOWN OS \`$os\`"
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/scripts/set-platform-specific-variables.sh
+++ b/.github/workflows/scripts/set-platform-specific-variables.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
 
 os="$1"
-github_env="${2:-$GITHUB_ENV}"
-
-function save-env () {
-    sed 's/^\s*//' >> $github_env
-}
 
 if [ "$os" = "Linux" ]; then
-    echo "
+    env=$(echo "
         ARCH=x86_64-linux-gnu-full
         EXT=tar.gz
         NU_BIN=nu
         NUPM=$HOME/nupm
         CWD=$PWD
-    " | save-env
+    ")
 elif [ "$os" = "Windows" ]; then
-    echo "
+    env=$(echo "
         ARCH=x86_64-pc-windows-msvc
         EXT=zip
         NU_BIN=nu.exe
         NUPM=$(echo $HOME | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')/nupm
         CWD=$(echo $PWD | tr '/' '\\' | sed 's/^\\\(.\)\\/\1:\\/')
-    " | save-env
+    ")
 elif [ "$os" = "macOS" ]; then
-    echo "
+    env=$(echo "
         ARCH=x86_64-apple-darwin
         EXT=tar.gz
         NU_BIN=nu
         NUPM=$HOME/nupm
         CWD=$PWD
-    " | save-env
+    ")
 else
     echo "UNKNOWN OS \`$os\`"
     exit 1
 fi
 
+echo $env | tr " " "\n"
 exit 0

--- a/.github/workflows/scripts/set-platform-specific-variables.sh
+++ b/.github/workflows/scripts/set-platform-specific-variables.sh
@@ -13,7 +13,7 @@ if [ "$os" = "Linux" ]; then
         EXT=tar.gz
         NU_BIN=nu
         NUPM=$HOME/nupm
-        CWD=$HOME
+        CWD=$PWD
     " | save-env
 elif [ "$os" = "Windows" ]; then
     echo "
@@ -29,7 +29,7 @@ elif [ "$os" = "macOS" ]; then
         EXT=tar.gz
         NU_BIN=nu
         NUPM=$HOME/nupm
-        CWD=$HOME
+        CWD=$PWD
     " | save-env
 else
     echo "UNKNOWN OS \`$os\`"


### PR DESCRIPTION
## Description
this PR moves the two biggest steps of the CI to two scripts
- `set-platform-specific-variables.sh`
- `install-nightly-nushell.sh`

my idea here is to both make the CI easier to read and to allow distributing these scripts to other CIs that might need to download Nushell from the nightly builds :yum: 