### PR TITLE
return a boolean from `nupm-home-prompt` and early exit

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -176,7 +176,9 @@ export def main [
     --path  # Install package from a directory with package.nuon given by 'name'
     --force(-f)  # Overwrite already installed package
 ]: nothing -> nothing {
-    nupm-home-prompt
+    if not (nupm-home-prompt) {
+        return
+    }
 
     if not $path {
         throw-error "missing_required_option" "`nupm install` currently requires a `--path` flag"

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -8,7 +8,7 @@ export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 #
-# returns true if the root directory exists of has been created, false otherwise
+# returns true if the root directory exists or has been created, false otherwise
 export def nupm-home-prompt []: nothing -> bool {
     if 'NUPM_HOME' not-in $env {
         error make --unspanned {

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -8,7 +8,7 @@ export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 #
-# returns true if the root directory has been created, false otherwise
+# returns true if the root directory exists of has been created, false otherwise
 export def nupm-home-prompt []: nothing -> bool {
     if 'NUPM_HOME' not-in $env {
         error make --unspanned {

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -7,7 +7,9 @@ export const DEFAULT_NUPM_HOME = ($nu.default-config-dir | path join "nupm")
 export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
-export def nupm-home-prompt [] {
+#
+# returns true if the root directory has been created, false otherwise
+export def nupm-home-prompt []: nothing -> bool {
     if 'NUPM_HOME' not-in $env {
         error make --unspanned {
             msg: "Internal error: NUPM_HOME environment variable is not set"
@@ -23,7 +25,7 @@ export def nupm-home-prompt [] {
             }
         }
 
-        return
+        return true
     }
 
     mut answer = ''
@@ -35,10 +37,12 @@ export def nupm-home-prompt [] {
     }
 
     if ($answer | str downcase) != 'y' {
-        return
+        return false
     }
 
     mkdir $env.NUPM_HOME
+
+    true
 }
 
 export def script-dir [--ensure]: nothing -> path {


### PR DESCRIPTION
should
- close https://github.com/nushell/nupm/issues/38

## Description
when the user answers something different than `y` or `Y`, `nupm-home-prompt` will return `false` and `nupm install` will not create the root of Nupm and will abort.