### PR TITLE
use the Nushell GitHub action targetting nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,4 @@ jobs:
         run: version
 
       - name: Run the tests
-        run: |
-          use ./nupm/
-          nupm test
+        run: nu --commands $"use ($env.PWD)/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: continuous-integration
 
 defaults:
   run:
-    shell: bash
+    shell: nu {0}
 
 env:
   CI_SCRIPTS: ".github/workflows/scripts"
@@ -26,16 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set platform-specific variables
-        run: bash $CI_SCRIPTS/set-platform-specific-variables.sh "${{ runner.os }}" >> "$GITHUB_ENV"
-
-      - name: Install Nushell from Nightly
-        run: bash $CI_SCRIPTS/install-nightly-nushell.sh "${{ env.ARCH }}" "${{ env.EXT }}" "${{ env.NU_BIN }}"
+      - uses: hustcer/setup-nu@v3.7
+        with:
+          version: nightly
 
       - name: Show Nushell Version
-        run: |
-          "$HOME/${{ env.NU_BIN }}" --commands "version"
+        run: version
 
       - name: Run the tests
-        run: |
-          "$HOME/${{ env.NU_BIN }}" --commands "use ${{ env.CWD }}/nupm/; nupm test"
+        run: nu --commands $"use ($env.PWD)/nupm/; nupm test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: nu {0}
 
+env:
+  NU_LOG_LEVEL: DEBUG
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ defaults:
   run:
     shell: nu {0}
 
-env:
-  CI_SCRIPTS: ".github/workflows/scripts"
-
 jobs:
   tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,6 @@ jobs:
         run: version
 
       - name: Run the tests
-        run: nu --commands $"use ($env.PWD)/nupm/; nupm test"
+        run: |
+          use ./nupm/
+          nupm test


### PR DESCRIPTION
## Description
thanks to @hustcer and the [`hustcer/setup-nu@v3.7` GitHub action](https://github.com/hustcer/setup-nu?tab=readme-ov-file#use-nu-nightly-version), we can now install the *nightly* builds of Nushell without relying on Bash scripts :pray: 

this PR implements the snippet from the doc linked above and uses `nu` as the default shell in the CI.


> **Note**
> i used this opportunity to set `NU_LOG_LEVEL` to `DEBUG` to have more information if we need that in later runs