### PR TITLE
add `--no-confirm` to `nupm install`

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -175,8 +175,9 @@ export def main [
     package # Name, path, or link to the package
     --path  # Install package from a directory with package.nuon given by 'name'
     --force(-f)  # Overwrite already installed package
+    --no-confirm # Allows to bypass the interactive confirmation, useful for scripting
 ]: nothing -> nothing {
-    if not (nupm-home-prompt) {
+    if not (nupm-home-prompt --no-confirm $no_confirm) {
         return
     }
 

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -11,7 +11,7 @@ export-env {
 
 # Nushell Package Manager
 export def main []: nothing -> nothing {
-    nupm-home-prompt
+    nupm-home-prompt --no-confirm false
 
     print 'enjoy nupm!'
 }

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -9,7 +9,7 @@ export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 #
 # returns true if the root directory exists or has been created, false otherwise
-export def nupm-home-prompt []: nothing -> bool {
+export def nupm-home-prompt [--no-confirm: bool]: nothing -> bool {
     if 'NUPM_HOME' not-in $env {
         error make --unspanned {
             msg: "Internal error: NUPM_HOME environment variable is not set"
@@ -25,6 +25,11 @@ export def nupm-home-prompt []: nothing -> bool {
             }
         }
 
+        return true
+    }
+
+    if $no_confirm {
+        mkdir $env.NUPM_HOME
         return true
     }
 


### PR DESCRIPTION
related to
- https://github.com/amtoine/nu-git-manager/pull/53

## Description
in https://github.com/amtoine/nu-git-manager/pull/53, i was trying to use `nupm install` in a CI to test the install of a package.
i hit a wall with `nupm install` which requires human confirmation when `NUPM_HOME` does not exist :thinking: 

i propose to add a `--no-confirm` option to bypass that confirmation in scripts.