### PR TITLE
add support for package versions

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -98,7 +98,7 @@ def install-modules [
             | where type == file
             | get name
             | each {|it|
-                open $it | str replace --all "{{ VERSION }}" $version | save --force $it
+                open $it | str replace --all "{{ NUPM_VERSION }}" $version | save --force $it
             }
     }
 

--- a/nupm/version.nu
+++ b/nupm/version.nu
@@ -1,0 +1,3 @@
+export def main []: nothing -> string {
+    "{{ VERSION }}"
+}

--- a/nupm/version.nu
+++ b/nupm/version.nu
@@ -1,3 +1,3 @@
 export def main []: nothing -> string {
-    "{{ VERSION }}"
+    "{{ NUPM_VERSION }}"
 }


### PR DESCRIPTION
## Description
this PR
- replaces all instances of `{{ VERSION }}` in the module files with `$"($package.name)@($package.version)"`
- adds a `nupm version` command to showcase how that works

when i install Nupm now, i have the following
```nushell
> nupm version
nupm@0.1.0
```