### PR TITLE
do not expand paths strictly before opening package file

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -102,7 +102,7 @@ def install-path [
     pkg_dir: path      # Directory (hopefully) containing 'package.nuon'
     --force(-f): bool  # Overwrite already installed package
 ] {
-    let pkg_dir = $pkg_dir | path expand --strict
+    let pkg_dir = $pkg_dir | path expand
 
     let package = open-package-file $pkg_dir
 


### PR DESCRIPTION
should close #44 

## Description
the `open-package-file` command already takes a package directory and checks if there is a `package.nuon` in there, throwing a clean error if not.

this PR removes the `--strict` option of the `path expand` just before `open-package-file` leading to the unhelpful error of #44.

### before
```nushell
> nupm install --path nu-git-manager --force
Error:   × Could not expand path
     ╭─[/home/amtoine/documents/repos/github.com/nushell/nupm/nupm/install.nu:104:1]
 104 │ ] {
 105 │     let pkg_dir = $pkg_dir | path expand --strict
     ·                   ────┬───
     ·                       ╰── could not be expanded (path might not exist, non-final component is not a directory, or other cause)
 106 │
     ╰────
```

### after
```nushell
> nupm install --path nu-git-manager --force
Error:   × package_file_not_found
  │ Could not find "package.nuon" in /home/amtoine/documents/repos/github.com/amtoine/nu-git-manager/nu-git-manager or any
  │ parent directory.
```