### PR TITLE
update the index

### DIFF
--- a/index.nuon
+++ b/index.nuon
@@ -6,7 +6,8 @@
     { package: "github.com:FMotalleb/nu_plugin_port_list" },
     { package: "github.com:FMotalleb/nu_plugin_port_scan" },
     { package: "github.com:FMotalleb/nu_plugin_qr_maker" },
-    { package: "github.com:amtoine/nu-git-manager" },
+    { package: "github.com:amtoine/nu-git-manager", dir: "pkgs/nu-git-manager" },
+    { package: "github.com:amtoine/nu-git-manager", dir: "pkgs/nu-git-manager-sugar" },
     { package: "github.com:amtoine/nu-pomodoro" },
     { package: "github.com:amtoine/nu-right-prompt" },
     { package: "github.com:amtoine/nu_plugin_explore" },
@@ -16,6 +17,7 @@
     { package: "github.com:amtoine/scripts", dir: "nu-scripts" },
     { package: "github.com:amtoine/scripts", dir: "nu-sound-manager" },
     { package: "github.com:amtoine/zellij-layouts", dir: "nu-zellij" },
-    { package: "github.com:nushell/nu_scripts" },
+    { package: "github.com:nushell/nu_scripts", dir: "nu-hooks" },
+    { package: "github.com:nushell/nu_scripts", dir: "themes" },
     { package: "github.com:nushell/nupm" },
 ]


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/pull/50
- https://github.com/amtoine/nu-git-manager/pull/140
- https://github.com/nushell/nu_scripts/pull/700

## Description
#50 forces some packages with multiple modules to be split into multiple packages.
this is the case of `amtoine/nu-git-manager` and `nushell/nu_scripts` and this PR reflects this new set of packages.

> **Note**
> the script given as an example in https://github.com/nushell/nupm/pull/49 might not work for now with the ongoing transition from `package.nuon` to `nupm.nuon` in https://github.com/nushell/nupm/pull/49