### PR TITLE
remove deprecated `--switch: bool`

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -151,7 +151,7 @@ export def main [
     --force(-f)  # Overwrite already installed package
     --no-confirm # Allows to bypass the interactive confirmation, useful for scripting
 ]: nothing -> nothing {
-    if not (nupm-home-prompt --no-confirm $no_confirm) {
+    if not (nupm-home-prompt --no-confirm=$no_confirm) {
         return
     }
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -34,7 +34,7 @@ def open-package-file [dir: path] {
 def install-scripts [
     pkg_dir: path        # Package directory
     scripts_dir: path    # Target directory where to install
-    --force(-f): bool    # Overwrite already installed scripts
+    --force(-f)          # Overwrite already installed scripts
 ]: list<path> -> nothing {
     each {|script|
         let src_path = $pkg_dir | path join $script
@@ -64,7 +64,7 @@ def install-scripts [
 # Install package from a directory containing 'project.nuon'
 def install-path [
     pkg_dir: path      # Directory (hopefully) containing 'nupm.nuon'
-    --force(-f): bool  # Overwrite already installed package
+    --force(-f)        # Overwrite already installed package
 ] {
     let pkg_dir = $pkg_dir | path expand
 
@@ -103,7 +103,7 @@ def install-path [
                 log debug $"installing scripts for package ($package.name)"
 
                 $package.scripts
-                | install-scripts $pkg_dir (script-dir --ensure) --force $force
+                | install-scripts $pkg_dir (script-dir --ensure) --force=$force
             }
         },
         "script" => {
@@ -111,7 +111,7 @@ def install-path [
 
             [ ($pkg_dir | path join $"($package.name).nu") ]
             | append ($package.scripts? | default [])
-            | install-scripts $pkg_dir (script-dir --ensure) --force $force
+            | install-scripts $pkg_dir (script-dir --ensure) --force=$force
         },
         "custom" => {
             let build_file = $pkg_dir | path join "build.nu"
@@ -159,5 +159,5 @@ export def main [
         throw-error "missing_required_option" "`nupm install` currently requires a `--path` flag"
     }
 
-    install-path $package --force $force
+    install-path $package --force=$force
 }

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -14,7 +14,7 @@ export-env {
 
 # Nushell Package Manager
 export def main []: nothing -> nothing {
-    nupm-home-prompt --no-confirm false
+    nupm-home-prompt --no-confirm=false
 
     print 'enjoy nupm!'
 }

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -9,7 +9,7 @@ export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 #
 # returns true if the root directory exists or has been created, false otherwise
-export def nupm-home-prompt [--no-confirm: bool]: nothing -> bool {
+export def nupm-home-prompt [--no-confirm]: nothing -> bool {
     if 'NUPM_HOME' not-in $env {
         error make --unspanned {
             msg: "Internal error: NUPM_HOME environment variable is not set"


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/11365
- https://github.com/amtoine/nu-git-manager/pull/154

## description
this PR will suppress the deprecation warning from https://github.com/nushell/nushell/pull/11365 which is deprecating `: bool` annotations for switches.

this didn't break anything but did show a bunch of spurious deprecation warnings in CI for instance: https://github.com/amtoine/nu-git-manager/actions/runs/7307569422/job/19913395508#step:6:17