### PR TITLE
flake init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Nix build output directory
+result
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,115 @@
+/*
+NOTE:
+If you make changes to this file please run `nix fmt` and `nix flake check`
+when you're done.
+
+To update this flake run `nix flake update`.
+
+To build `nupm` run `nix build .#nupm-lib`.
+
+To test `nupm` run `nix flake check`.
+
+To enter a development shell run `nix develop`.
+*/
+{
+  description = "A manager for Nushell packages.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      perSystem = {
+        pkgs,
+        system,
+        ...
+      }: {
+        packages = with pkgs; rec {
+          # This packages nupm as a library where it can be imported and used a
+          # module.
+          nupm-lib = stdenvNoCC.mkDerivation {
+            name = "nupm";
+            src = ./.;
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/share/nupm
+              mv ./* $out/share/nupm
+
+              runHook postInstall
+            '';
+          };
+
+          # This packages the test functionality and makes it portable. You can
+          # test your own applications with `nix run github:nushell/nupm#nupm-test`
+          nupm-test = writeShellApplication {
+            runtimeInputs = [nupm-lib nushell];
+            name = "nupm-test";
+            text = ''
+              nu --no-config-file \
+                --commands '
+                  use ${nupm-lib}/share/nupm/nupm
+
+                  nupm test
+                '
+            '';
+          };
+        };
+
+        # This is the formatter for `.nix` files. Eventually, `nufmt` and
+        # `treefmt` could be included for tree-wide formatting.
+        formatter = pkgs.alejandra;
+
+        # These are the nix tests. At the moment, this is only wrapping `nupm
+        # test` but can have many tests including `pre-commit` checks,
+        # formatters, linters, etc.
+        checks = {
+          nupm-tests = with pkgs;
+            stdenvNoCC.mkDerivation {
+              inherit system;
+              name = "nupm tests";
+              src = ./.;
+              buildInputs = [nushell];
+
+              buildPhase = ''
+                nu --no-config-file \
+                  --commands '
+                    use ./nupm
+
+                    nupm test
+                  '
+              '';
+
+              installPhase = ''
+                touch $out
+              '';
+            };
+        };
+
+        # This holds reproducible developer environments. Eventually this can
+        # also have an output for `nushell-nightly` if it's needed for
+        # development.
+        devShells = with pkgs; {
+          default = mkShell {
+            buildInputs = [nushell];
+
+            # This can also include environment variables ex:
+            # NU_LIB_DIRS = ../modules;
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
<!-- related issues, e.g. "will close #123" -->

## Description
<!-- describe in a few words the changes -->
I know the nushell maintainers aren't super familiar with nix and while I am
completely unqualified to explain nix to anyone, I can at least provide a tl;dr
about flakes and what the files do.

### flake.nix

`flake.nix` is a (purish) function that describes how to build and package
applications. The `inputs` to this function are typically buildtime/runtime
dependencies (`rustc`, `cargo`, `nushell`, etc.), and developer tooling
(`clippy`, `rust-analyzer`, etc.).

The function `outputs` can contain multiple things including runnable
applications, developer environments, nix modules, etc.


### flake.lock

`flake.lock` version-pins the `inputs` to the function. This means you get extremely
consistent reproducibility to the build function `outputs`. This is one of the
main reasons people love flakes so much.


### result/

`nix build` will symlink the built derivation to the `result` directory.
This should be included as an entry into `.gitignore`.



I also left a some comments in `flake.nix` to help explain a few things.
