### PR TITLE
Adding basic doc generation functionality

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -1,0 +1,8 @@
+## Modules
+- [`nupm`](./nupm/README.md)
+
+## Commands
+- [`nupm`](nupm/nupm.md)
+- [`doc`](doc/nupm/doc.md)
+- [`install`](install/nupm/install.md)
+- [`test`](test/nupm/test.md)

--- a/docs/commands/nupm/README.md
+++ b/docs/commands/nupm/README.md
@@ -1,0 +1,11 @@
+# Module `nupm`
+## Description
+
+
+## Commands
+- [`nupm`](nupm.md)
+
+## Submodules
+- [`doc`](doc/README.md)
+- [`install`](install/README.md)
+- [`test`](test/README.md)

--- a/docs/commands/nupm/doc/README.md
+++ b/docs/commands/nupm/doc/README.md
@@ -1,0 +1,8 @@
+# Module `doc nupm`
+## Description
+
+
+## Commands
+- [`doc`](doc.md)
+
+## Submodules

--- a/docs/commands/nupm/doc/doc.md
+++ b/docs/commands/nupm/doc/doc.md
@@ -1,0 +1,37 @@
+# `doc` (`doc nupm`)
+Generates markdown documentation of the current or provided nushell modules.
+
+## Examples
+Basic usage
+```nushell
+nupm doc
+```
+
+## Parameters
+- parameter_name: documentation-dir
+- parameter_type: named
+- syntax_shape: path
+- is_optional: true
+- description: The directory to put generated documentation in.
+---
+- parameter_name: library-paths
+- parameter_type: named
+- syntax_shape: list<path>
+- is_optional: true
+- description: A list of paths to nushell modules to generate documentation for.
+---
+- parameter_name: plugin-paths
+- parameter_type: named
+- syntax_shape: list<path>
+- is_optional: true
+- description: NOT IMPLEMENTED YET
+---
+- parameter_name: not-local
+- parameter_type: switch
+- is_optional: true
+- description: Tells the command not to generate documentation for the current directory if the current directory has a nupm.nuon file in it.
+
+## Signatures
+| input     | output    |
+| --------- | --------- |
+| `nothing` | `nothing` |

--- a/docs/commands/nupm/install/README.md
+++ b/docs/commands/nupm/install/README.md
@@ -1,0 +1,8 @@
+# Module `install nupm`
+## Description
+
+
+## Commands
+- [`install`](install.md)
+
+## Submodules

--- a/docs/commands/nupm/install/install.md
+++ b/docs/commands/nupm/install/install.md
@@ -1,0 +1,32 @@
+# `install` (`install nupm`)
+Install a nupm package
+
+
+
+## Parameters
+- parameter_name: package
+- parameter_type: positional
+- syntax_shape: any
+- is_optional: false
+- description: Name, path, or link to the package
+---
+- parameter_name: path
+- parameter_type: switch
+- is_optional: true
+- description: Install package from a directory with nupm.nuon given by 'name'
+---
+- parameter_name: force
+- parameter_type: switch
+- is_optional: true
+- short_flag: f
+- description: Overwrite already installed package
+---
+- parameter_name: no-confirm
+- parameter_type: switch
+- is_optional: true
+- description: Allows to bypass the interactive confirmation, useful for scripting
+
+## Signatures
+| input     | output    |
+| --------- | --------- |
+| `nothing` | `nothing` |

--- a/docs/commands/nupm/nupm.md
+++ b/docs/commands/nupm/nupm.md
@@ -1,0 +1,12 @@
+# `nupm` (`nupm `)
+Nushell Package Manager
+
+
+
+## Parameters
+
+
+## Signatures
+| input     | output    |
+| --------- | --------- |
+| `nothing` | `nothing` |

--- a/docs/commands/nupm/test/README.md
+++ b/docs/commands/nupm/test/README.md
@@ -1,0 +1,8 @@
+# Module `test nupm`
+## Description
+
+
+## Commands
+- [`test`](test.md)
+
+## Submodules

--- a/docs/commands/nupm/test/test.md
+++ b/docs/commands/nupm/test/test.md
@@ -1,0 +1,27 @@
+# `test` (`test nupm`)
+Experimental test runner
+
+
+
+## Parameters
+- parameter_name: filter
+- parameter_type: positional
+- syntax_shape: string
+- is_optional: true
+- description: Run only tests containing this substring
+---
+- parameter_name: dir
+- parameter_type: named
+- syntax_shape: path
+- is_optional: true
+- description: Directory where to run tests (default: $env.PWD)
+---
+- parameter_name: show-stdout
+- parameter_type: switch
+- is_optional: true
+- description: Show standard output of each test
+
+## Signatures
+| input     | output    |
+| --------- | --------- |
+| `nothing` | `nothing` |

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -4,4 +4,5 @@
     version: "0.1.0"
     description: "Nushell package manager"
     license: "LICENSE"
+    documentation-dir: "./docs/commands/"
 }

--- a/nupm/doc.nu
+++ b/nupm/doc.nu
@@ -1,0 +1,216 @@
+use std repeat
+use utils/utils.nu open-package-file
+
+# Runs a nu command in a shell without configs.
+def run-nu [code: string]: nothing -> any {
+    ^$nu.current-exe --no-config-file --commands ($code ++ " | to nuon") | from nuon
+}
+
+# Gets the module's metadata using the `scope` command.
+# TODO Plugins
+def get-module-metadata [
+    basic_module_metadata: record<name: string, path: path>
+]: nothing -> record<name: string, commands: list<string>, submodules: list<record>, path: path, parent_names: list<string>> {
+    run-nu $"
+        use ($basic_module_metadata.path)
+        scope modules | where name == ($basic_module_metadata.name) | into record | reject env_block
+    " | insert path $basic_module_metadata.path | insert parent_names []
+}
+
+# Generates the documentation for a given command.
+def document-command [
+    module_name: string,
+    full_module_name: string,
+    full_module_name_with_leading_path: string
+]: string -> string {
+    let command = $in
+
+    let command_file = $command
+        | str replace --all ' ' '-'
+        | path parse
+        | update extension md
+        | path join
+
+    let imported_command = if ($command == $module_name) { "" } else { $"'($command)'" }
+
+    let help = run-nu $"
+        use ($full_module_name_with_leading_path) ($imported_command)
+        scope commands | where name == '($command)' | into record
+    "
+
+    let signatures = $help.signatures | transpose | get column1
+
+    let page = [
+        $"# `($command)` \(`($full_module_name)`\)",
+        $help.usage,
+        "",
+        $help.extra_usage,
+        "",
+        "## Parameters",
+        (
+            $signatures.0
+                | where parameter_type not-in ["input", "output"]
+                | each {
+                    transpose
+                        | where not ($it.column1 | is-empty)
+                        | transpose --header-row
+                        | into record
+                        | to text
+                        | lines
+                        | str replace --regex '^' '- '
+                        | str join "\n"
+                }
+                | str join "\n---\n"
+        ),
+        "",
+        $"## Signatures",
+        (
+            $signatures
+                | each {
+                    where parameter_type in ["input", "output"]
+                        | select parameter_type syntax_shape
+                        | transpose --header-row
+                }
+                | flatten
+                | update input { $"`($in)`" }
+                | update output { $"`($in)`" }
+                | to md --pretty
+        ),
+    ]
+
+    $page | flatten | str join "\n" | save --force --append $command_file
+
+    $command_file
+}
+
+# /!\ will save each command encountered to the main index file as a side effect
+def document-module [
+    main_index: path,
+    documentation_dir: path,
+    module: record<name: string, commands: list<string>, submodules: list<record>, path: path, parent_names: list<string>>
+    depth?: int = 0,
+]: nothing -> nothing {
+
+    mkdir ($module.name | path basename)
+    cd ($module.name | path basename)
+
+    let full_module_name = $module.name + ' ' + ($module.parent_names | str join ' ')
+
+    let commands = if ($module.commands.name | is-empty) {
+        "no commands"
+    } else {
+        $module.commands.name | each {|command|
+            let command_file = ($command
+            | document-command $module.name $full_module_name $module.path)
+
+            let full_command_file = (
+                $full_module_name | str replace --all ' ' '/' | path join $command_file
+            )
+            $"- [`($command)`]\(($full_command_file)\)\n" | save --force --append $main_index
+
+            $"- [`($command)`]\(($command_file)\)"
+        }
+    }
+
+    let submodules = $module.submodules | each {|submodule|
+        $"- [`($submodule.name)`]\(($submodule.name)/README.md\)"
+    }
+
+    let submodules_section = match $submodules {
+        null => [],
+        $sub => (["", "## Submodules", $submodules]),
+    }
+
+    let page = [
+        $"# Module `($full_module_name | str trim)`",
+        "## Description",
+        $module.usage,
+        "",
+        "## Commands",
+        $commands,
+        ...$submodules_section,
+    ]
+
+    $page | flatten | str join "\n" | save --force README.md
+
+    for submodule in $module.submodules {
+        let submodule_path = ($module.path + ' ' + $submodule.name)
+        let parent_names = $module.parent_names | append $module.name
+        let modified_submodule = $submodule | insert path $submodule_path | insert parent_names $parent_names
+        document-module $main_index $documentation_dir $modified_submodule ($depth + 1)
+    }
+}
+
+const metadata_filename = 'nupm.nuon'
+
+# Generates markdown documentation of the current or provided nushell modules.
+#
+# ## Examples
+# Basic usage
+# ```nushell
+# nupm doc
+# ```
+export def main [
+    --documentation-dir: path # The directory to put generated documentation in.
+    --library-paths: list<path> = [] # A list of paths to nushell modules to generate documentation for.
+    --plugin-paths: list<path> = [] # NOT IMPLEMENTED YET
+    --not-local # Tells the command not to generate documentation for the current directory if the current directory has a nupm.nuon file in it.
+]: nothing -> nothing {
+
+    let package_metadata = try {
+        let all_package_metadata = open-package-file (pwd)
+        
+        let local_module = if (not $not_local) and (not ($all_package_metadata == null)) {
+            match $all_package_metadata.type {
+                'module' => ((pwd) | path join $all_package_metadata.name),
+                'script' => { print 'Script package type doc generation not implemented yet.' },
+                'custom' => { print 'Custom package type doc generation not implemented yet.' },
+            }
+        } else {
+            []
+        }
+
+        {
+            local_module: $local_module,
+            doc_dir: ($all_package_metadata | get -i documentation-dir),
+        }
+    } catch {
+
+        {
+            local_module: [],
+            doc_dir: null,
+        }
+    }
+
+    let modules = $library_paths ++ $package_metadata.local_module | each {{ name: ($in | path basename), path: $in }}
+
+    let documentation_dir = if $documentation_dir != null {
+        $documentation_dir
+    } else if ($package_metadata | get -i doc_dir) != null {
+        $package_metadata.doc_dir
+    } else {
+        "./docs/"
+    }
+
+    let documentation_dir = $documentation_dir | path expand
+
+    rm --force --recursive $documentation_dir
+    mkdir $documentation_dir
+    cd $documentation_dir
+
+    "## Modules\n" | save --force --append README.md
+    for module in ($modules | get name) {
+        $"- [`($module)`]\(./($module)/README.md\)\n" | save --force --append README.md
+    }
+
+    "\n" | save --force --append README.md
+    "## Commands\n" | save --force --append README.md
+
+    let root = pwd | path dirname
+    let main_index = $root | path join $documentation_dir "README.md"
+
+    for module in $modules {
+        let module_metadata = get-module-metadata $module
+        document-module $main_index $documentation_dir $module_metadata
+    }
+}

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -2,6 +2,7 @@ use utils/dirs.nu [ DEFAULT_NUPM_HOME DEFAULT_NUPM_TEMP nupm-home-prompt ]
 
 export module install.nu
 export module test.nu
+export module doc.nu
 
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing

--- a/nupm/utils/utils.nu
+++ b/nupm/utils/utils.nu
@@ -1,0 +1,26 @@
+use log.nu throw-error
+
+export def open-package-file [dir: path] {
+    let package_file = $dir | path join "nupm.nuon"
+
+    if not ($package_file | path exists) {
+        throw-error "package_file_not_found" (
+            $'Could not find "nupm.nuon" in ($dir) or any parent directory.'
+        )
+    }
+
+    let package = open $package_file
+
+    log debug "checking package file for missing required keys"
+    let required_keys = [$. $.name $.version $.type]
+    let missing_keys = $required_keys
+        | where {|key| ($package | get -i $key) == null}
+    if not ($missing_keys | is-empty) {
+        throw-error "invalid_package_file" (
+            $"($package_file) is missing the following required keys:"
+            + $" ($missing_keys | str join ', ')"
+        )
+    }
+
+    $package
+}


### PR DESCRIPTION
## Description

This change adds basic documentation generation functionality to nupm.

Using the current package's code, or paths to other modules it will generate a directory of markdown files based on the internal metadata about the modules and commands (data from `scope`).

The majority of the code is shamelessly stolen from @amtoine's [nu-git-manager toolkit script](https://github.com/amtoine/nu-git-manager/blob/1f4153da8db3b59eafe0fac86fadb84cca2e6e15/toolkit.nu) and modified.

There's a lot of basic functionality missing that I'd like to add like generating HTML and documenting plugins, but this is a good first step.

I also added the generated documentation for nupm itself because it seemed appropriate.