### PR TITLE
remove the destination only if it exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,6 @@ jobs:
         run: version
 
       - name: Run the tests
-        run: nu --commands $"use ($env.PWD)/nupm/; nupm test"
+        run: |
+          nu --commands $"use ($env.PWD)/nupm/; nupm install --no-confirm --force --path ."
+          nu --commands $"use ($env.PWD)/nupm/; nupm test"

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -87,7 +87,9 @@ def install-path [
             let destination = $module_dir | path join $package.name
 
             if $force {
-                rm --recursive --force $destination
+                if ($destination | path exists) {
+                    rm --recursive --force $destination
+                }
             }
 
             if ($destination | path type) == dir {


### PR DESCRIPTION
- should close #61 

## Description
`nupm install --force` should not try to `rm` the content of `$destination` if it does not exist.
this PR adds a check for that and a test to the CI.