### PR TITLE
Revert "remove the destination only if it exists (#62)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,4 @@ jobs:
         run: version
 
       - name: Run the tests
-        run: |
-          nu --commands $"use ($env.PWD)/nupm/; nupm install --no-confirm --force --path ."
-          nu --commands $"use ($env.PWD)/nupm/; nupm test"
+        run: nu --commands $"use ($env.PWD)/nupm/; nupm test"

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -87,9 +87,7 @@ def install-path [
             let destination = $module_dir | path join $package.name
 
             if $force {
-                if ($destination | path exists) {
-                    rm --recursive --force $destination
-                }
+                rm --recursive --force $destination
             }
 
             if ($destination | path type) == dir {


### PR DESCRIPTION
related to
- https://github.com/nushell/nupm/pull/62
- https://github.com/nushell/nushell/pull/11656

## Description
this commit reverts https://github.com/nushell/nupm/pull/62 because it was just a bug introduced recently and now fixed in https://github.com/nushell/nushell/pull/11656.