### PR TITLE
:bug: fix extra `)`

### DIFF
--- a/nupm/utils/misc.nu
+++ b/nupm/utils/misc.nu
@@ -20,7 +20,6 @@ export def check-cols [
         if not ($missing_cols | is-empty) {
             throw-error ($"Missing the following required columns in ($what):"
                 + $" ($missing_cols | str join ', ')")
-            )
         }
     }
 
@@ -30,7 +29,6 @@ export def check-cols [
         if not ($extra_cols | is-empty) {
             throw-error ($"Got the following extra columns in ($what):"
                 + $" ($extra_cols | str join ', ')")
-            )
         }
     }
 


### PR DESCRIPTION
I've compiled nushell from latest `main` commit and threw something like:
```
Error: nu::parser::unbalanced_delimiter

  × Unbalanced delimiter.
    ╭─[C:\Users\AucaMaillo\other-repos\nupm\nupm\utils\misc.nu:23:13]
 22 │                 + $" ($missing_cols | str join ', ')")
 23 │             )
    ·             ┬
    ·             ╰── unbalanced ( and )
 24 │         }
    ╰────
```
So I corrected the typo.