### PR TITLE
add `main` branch of `tmux-sessionizer`

### DIFF
--- a/registry.nuon
+++ b/registry.nuon
@@ -277,6 +277,13 @@
             "https://github.com/amtoine/tmux-sessionizer",
             "18f5cef534b8b494e4dee645e453231dd5d1bc4c",
             .
+        ],
+        [
+            tmux-sessionizer,
+            "main",
+            "https://github.com/amtoine/tmux-sessionizer",
+            "main",
+            .
         ]
     ]
 }


### PR DESCRIPTION
## Description
[`tmux-sessionizer`](https://github.com/amtoine/tmux-sessionizer) does not really have versions because i've been lazy with that package of mine :rofl: 

i thought adding the `main` branch as a version could be nice.