### PR TITLE
Add `nupm status`; List all files of module

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -4,39 +4,9 @@ use utils/completions.nu complete-registries
 use utils/dirs.nu [ nupm-home-prompt cache-dir module-dir script-dir tmp-dir ]
 use utils/log.nu throw-error
 use utils/misc.nu check-cols
+use utils/package.nu open-package-file
 use utils/registry.nu search-package
 use utils/version.nu filter-by-version
-
-def open-package-file [dir: path] {
-    if not ($dir | path exists) {
-        throw-error "package_dir_does_not_exist" (
-            $"Package directory ($dir) does not exist"
-        )
-    }
-
-    let package_file = $dir | path join "nupm.nuon"
-
-    if not ($package_file | path exists) {
-        throw-error "package_file_not_found" (
-            $'Could not find "nupm.nuon" in ($dir) or any parent directory.'
-        )
-    }
-
-    let package = open $package_file
-
-    log debug "checking package file for missing required keys"
-    let required_keys = [$. $.name $.version $.type]
-    let missing_keys = $required_keys
-        | where {|key| ($package | get -i $key) == null}
-    if not ($missing_keys | is-empty) {
-        throw-error "invalid_package_file" (
-            $"($package_file) is missing the following required keys:"
-            + $" ($missing_keys | str join ', ')"
-        )
-    }
-
-    $package
-}
 
 # Install list of scripts into a directory
 #

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -5,6 +5,7 @@ use utils/dirs.nu [
 export module install.nu
 export module test.nu
 export module search.nu
+export module status.nu
 
 export-env {
     # Ensure that $env.NUPM_HOME is always set when running nupm. Any missing

--- a/nupm/status.nu
+++ b/nupm/status.nu
@@ -1,0 +1,18 @@
+use utils/log.nu throw-error
+use utils/package.nu [open-package-file list-package-files]
+
+
+# Display status of a package
+export def main [
+    path?: path  # path to the package
+] -> record<filename: string> {
+    let path = $path | default $env.PWD | path expand
+
+    let pkg = open-package-file $path
+    let files = list-package-files $path $pkg
+
+    {
+        ...$pkg
+        files: $files
+    }
+}

--- a/nupm/utils/package.nu
+++ b/nupm/utils/package.nu
@@ -1,0 +1,68 @@
+# Open nupm.nuon
+export def open-package-file [dir: path] {
+    if not ($dir | path exists) {
+        throw-error "package_dir_does_not_exist" (
+            $"Package directory ($dir) does not exist"
+        )
+    }
+
+    let package_file = $dir | path join "nupm.nuon"
+
+    if not ($package_file | path exists) {
+        throw-error "package_file_not_found" (
+            $'Could not find "nupm.nuon" in ($dir) or any parent directory.'
+        )
+    }
+
+    let package = open $package_file
+
+    log debug "checking package file for missing required keys"
+    let required_keys = [$. $.name $.version $.type]
+    let missing_keys = $required_keys
+        | where {|key| ($package | get -i $key) == null}
+    if not ($missing_keys | is-empty) {
+        throw-error "invalid_package_file" (
+            $"($package_file) is missing the following required keys:"
+            + $" ($missing_keys | str join ', ')"
+        )
+    }
+
+    $package
+}
+
+# Lists files of a package
+#
+# This will be useful for file integrity checks
+export def list-package-files [pkg_dir: path, pkg: record] -> list<path> {
+    let activation = match $pkg.type {
+        'module' => $'use ($pkg.name)'
+        'script' => {
+            # we'd have to call `source script.nu` which would run the script
+            throw-error 'Checking status of script package is not supported'
+        }
+        _ => null
+    }
+
+    let src = $"
+        ($activation)
+        view files
+        | where \($it.filename | str starts-with ($pkg_dir)\)
+        | get filename
+        | to nuon"
+
+    mut files = []
+
+    if $activation != null {
+        cd $pkg_dir
+        let out = nu -c $src | complete
+        if $out.exit_code == 0 {
+            $files ++= ($out.stdout | from nuon)
+        }
+    }
+
+    $files ++= ($pkg.scripts?
+        | default []
+        | each {|script| $pkg_dir | path join $script})
+
+    $files
+}

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -122,3 +122,13 @@ export def search-registry [] {
         assert ((nupm search spam | get pkgs.0 | length) == 4)
     }
 }
+
+export def nupm-status-module [] {
+    with-test-env {
+        let files = (nupm status tests/packages/spam_module).files
+        assert ($files.0 ends-with (
+            [tests packages spam_module spam_module mod.nu] | path join))
+        assert ($files.1 ends-with (
+            [tests packages spam_module script.nu] | path join))
+    }
+}


### PR DESCRIPTION
<!-- related issues, e.g. "will close #123" -->

## Description
<!-- describe in a few words the changes -->

I implemented a way how to fetch all files used by a `module` package (by calling `use module; view files ...`). This will later allow generating a package's file list, which will be used for file integrity checks.

Implemented a `nupm status` as a proof-of-concept to demonstrate this.

Currently, `script` packages are unsupported because it would require calling `source` => it would evaluate the package which we don't want. I'm considering updating Nushell's `nu-check` and making it optionally list all the parsed files.

`custom` packages do not list any files. Since they don't have any known structure, package authors would probably need to put a list of installed files to `nupm.nuon` (same will be for plugins).

`$.scripts` fiels in `nupm.nuon` is respected.


