### PR TITLE
rename default registry

### DIFF
--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -23,7 +23,7 @@ export-env {
     # TODO: Add `nupm registry` for showing info about registries
     # TODO: Add `nupm registry add/remove` to add/remove registry from the env?
     $env.NUPM_REGISTRIES = {
-        nupm_test: 'https://raw.githubusercontent.com/nushell/nupm/main/registry.nuon'
+        nushell: 'https://raw.githubusercontent.com/nushell/nupm/main/registry.nuon'
     }
 }
 


### PR DESCRIPTION
## Description
i thought it was a bit strange to read `nupm_test` in the output of `nupm search` for the official registry of Nushell :open_mouth: 

this PR renames it to `nushell` for now.
maybe `official`?