### PR TITLE
Set default registry

### DIFF
--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,5 +1,6 @@
 use utils/dirs.nu [
-    DEFAULT_NUPM_HOME DEFAULT_NUPM_TEMP DEFAULT_NUPM_CACHE  nupm-home-prompt
+    DEFAULT_NUPM_HOME DEFAULT_NUPM_TEMP DEFAULT_NUPM_CACHE
+    DEFAULT_NUPM_REGISTRIES nupm-home-prompt
 ]
 
 export module install.nu
@@ -22,9 +23,8 @@ export-env {
     #       good enough for now.
     # TODO: Add `nupm registry` for showing info about registries
     # TODO: Add `nupm registry add/remove` to add/remove registry from the env?
-    $env.NUPM_REGISTRIES = {
-        nupm_test: 'https://raw.githubusercontent.com/nushell/nupm/main/registry.nuon'
-    }
+    $env.NUPM_REGISTRIES = ($env.NUPM_REGISTRIES?
+        | default $DEFAULT_NUPM_REGISTRIES)
 }
 
 # Nushell Package Manager

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -10,6 +10,11 @@ export const DEFAULT_NUPM_CACHE = ($nu.default-config-dir
 # Default temporary path for various nupm purposes
 export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
+# Default registry
+export const DEFAULT_NUPM_REGISTRIES = {
+    nupm_test: 'https://raw.githubusercontent.com/nushell/nupm/main/registry.nuon'
+}
+
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.
 #
 # returns true if the root directory exists or has been created, false otherwise

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -132,3 +132,18 @@ export def nupm-status-module [] {
             [tests packages spam_module script.nu] | path join))
     }
 }
+
+export def env-vars-are-set [] {
+    $env.NUPM_HOME = null
+    $env.NUPM_TEMP = null
+    $env.NUPM_CACHE = null
+    $env.NUPM_REGISTRIES = null
+
+    use ../nupm/utils/dirs.nu
+    use ../nupm
+
+    assert equal $env.NUPM_HOME $dirs.DEFAULT_NUPM_HOME
+    assert equal $env.NUPM_TEMP $dirs.DEFAULT_NUPM_TEMP
+    assert equal $env.NUPM_CACHE $dirs.DEFAULT_NUPM_CACHE
+    assert equal $env.NUPM_REGISTRIES $dirs.DEFAULT_NUPM_REGISTRIES
+}


### PR DESCRIPTION
<!-- related issues, e.g. "will close #123" -->

## Description
<!-- describe in a few words the changes -->

Sets default registry if none is set. The default value is set in `dirs.nu` even though it points to a file, but we'll probably need to break up the registry file to a directory structure for better maintainability.

Fixes https://github.com/nushell/nupm/issues/79
