### PR TITLE
add `nu-fonts-install` and `nu-discord-update`

### DIFF
--- a/registry.nuon
+++ b/registry.nuon
@@ -305,6 +305,20 @@
             "https://github.com/amtoine/tmux-sessionizer",
             "main",
             .
+        ],
+        [
+            nu-discord-update,
+            "0.1.0",
+            "https://github.com/amtoine/nu-discord-update",
+            "0.1.0",
+            .
+        ],
+        [
+            nu-fonts-install,
+            "0.1.0",
+            "https://github.com/amtoine/nu-fonts-install",
+            "0.1.0",
+            .
         ]
     ]
 }

--- a/registry.nuon
+++ b/registry.nuon
@@ -310,14 +310,14 @@
             nu-discord-update,
             "0.1.0",
             "https://github.com/amtoine/nu-discord-update",
-            "0.1.0",
+            "0284223340519630ee94d56c224cf8611abe2d0b",
             .
         ],
         [
             nu-fonts-install,
             "0.1.0",
             "https://github.com/amtoine/nu-fonts-install",
-            "0.1.0",
+            "6b03e9eec09c6784393a725308c34d301a67f7e4",
             .
         ]
     ]


### PR DESCRIPTION
## Description
this PR adds the two following packages, taken from my config, to the registry:
- [`nu-fonts-install`](https://github.com/amtoine/nu-fonts-install): install fonts easily, supports _Nerd_ fonts and the GitHub's Monaspace ones
- [`nu-discord-update`](https://github.com/amtoine/nu-discord-update): updates the Discord client when it complains about updates on Arch at least lol