### PR TITLE
add missing version of `nu_plugin_clipboard`

### DIFF
--- a/registry.nuon
+++ b/registry.nuon
@@ -55,6 +55,13 @@
             .
         ],
         [
+            nu_plugin_clipboard,
+            "0.92.1",
+            "https://github.com/FMotalleb/nu_plugin_clipboard",
+            "98d7102",
+            .
+        ],
+        [
             nu_plugin_desktop_notifications,
             "1.0.7",
             "https://github.com/FMotalleb/nu_plugin_desktop_notifications",


### PR DESCRIPTION
related to
- #86 

## Description
uses [one of the latest commits of `nu_plugin_clipboard`](https://github.com/FMotalleb/nu_plugin_clipboard/commit/98d71029ca5b7a722fbe6992e9700f800ce7f802) as the anchor point to install a version compatible with Nushell 0.92.

> **Important**
> this will likely create a conflict with #86 but i wanted to have that plugin added, it's too useful :wink: 