### PR TITLE
bump hustcer/setup-nu to 3.10 for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hustcer/setup-nu@v3.7
+      - uses: hustcer/setup-nu@v3.10
         with:
           version: nightly
 


### PR DESCRIPTION
as per title, the CI is now failing for versions before 3.10, see the failed runs of https://github.com/nushell/nupm/pull/88