### PR TITLE
add `nu_plugin_clipboard` versions 0.93.0 and 0.94.0

### DIFF
--- a/registry.nuon
+++ b/registry.nuon
@@ -62,6 +62,13 @@
             .
         ],
         [
+            nu_plugin_clipboard,
+            "0.93.0",
+            "https://github.com/FMotalleb/nu_plugin_clipboard",
+            "1788d2c",
+            .
+        ],
+        [
             nu_plugin_desktop_notifications,
             "1.0.7",
             "https://github.com/FMotalleb/nu_plugin_desktop_notifications",

--- a/registry.nuon
+++ b/registry.nuon
@@ -69,6 +69,13 @@
             .
         ],
         [
+            nu_plugin_clipboard,
+            "0.94.0",
+            "https://github.com/FMotalleb/nu_plugin_clipboard",
+            "0a349e7",
+            .
+        ],
+        [
             nu_plugin_desktop_notifications,
             "1.0.7",
             "https://github.com/FMotalleb/nu_plugin_desktop_notifications",


### PR DESCRIPTION
related to
- https://github.com/FMotalleb/nu_plugin_clipboard/pull/5
- https://github.com/nushell/nupm/pull/87 (followup)
- https://github.com/nushell/nupm/pull/86 (conflict)

## Description
there's two new versions of `nu_plugin_clipboard`, compatible with Nushell 0.93.0 and 0.94.0 :wink: 