### PR TITLE
Import std/log environment; CI: Update Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        platform: [windows-latest, macos-latest, ubuntu-24.04]
 
     runs-on: ${{ matrix.platform }}
 

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -238,6 +238,7 @@ export def main [
     --force(-f)  # Overwrite already installed package
     --no-confirm  # Allows to bypass the interactive confirmation, useful for scripting
 ]: nothing -> nothing {
+    use std/log
     if not (nupm-home-prompt --no-confirm=$no_confirm) {
         return
     }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -1,5 +1,3 @@
-use std log
-
 use utils/completions.nu complete-registries
 use utils/dirs.nu [ nupm-home-prompt cache-dir module-dir script-dir tmp-dir ]
 use utils/log.nu throw-error
@@ -238,7 +236,6 @@ export def main [
     --force(-f)  # Overwrite already installed package
     --no-confirm  # Allows to bypass the interactive confirmation, useful for scripting
 ]: nothing -> nothing {
-    use std/log
     if not (nupm-home-prompt --no-confirm=$no_confirm) {
         return
     }

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -1,3 +1,5 @@
+use std/log
+
 use utils/dirs.nu [
     DEFAULT_NUPM_HOME DEFAULT_NUPM_TEMP DEFAULT_NUPM_CACHE
     DEFAULT_NUPM_REGISTRIES nupm-home-prompt
@@ -26,6 +28,8 @@ export-env {
     # TODO: Add `nupm registry add/remove` to add/remove registry from the env?
     $env.NUPM_REGISTRIES = ($env.NUPM_REGISTRIES?
         | default $DEFAULT_NUPM_REGISTRIES)
+        
+    use std/log []
 }
 
 # Nushell Package Manager


### PR DESCRIPTION
Will fix [this issue](https://github.com/nushell/nushell/issues/14109) but its not a good fix anyway 

## Description

This is a hotfix PR to address an unusual issue with the `std log` package in Nushell. When the log is imported during the initialization stage, it doesn’t persist long enough to be fully available at runtime, specifically, the environment variables seem to disappear, although the log function itself remains accessible. This is a temporary fix and might not be the final solution. It could potentially be a bug in Nushell, but unfortunately, I don't have the time to investigate it further.

for more information please check [this issue](https://github.com/nushell/nushell/issues/14109)

I think this fix changes the output of the nupm, Plz close this PR if you found any real solution