### PR TITLE
Fix: Hash detection affects all Search results

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -207,6 +207,11 @@ def fetch-package [
         throw-error $'No package matching version `($version)`'
     }
 
+    if $pkg.hash_mismatch != true {
+      throw-error ($'Content of package file ($pkg.path)'
+                        + $' does not match expected hash') 
+    }
+
     print $pkg
 
     if $pkg.type == 'git' {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -207,9 +207,9 @@ def fetch-package [
         throw-error $'No package matching version `($version)`'
     }
 
-    if $pkg.hash_mismatch != true {
+    if $pkg.hash_mismatch == true {
       throw-error ($'Content of package file ($pkg.path)'
-                        + $' does not match expected hash') 
+                        + $' does not match expected hash')
     }
 
     print $pkg

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -207,6 +207,11 @@ def fetch-package [
         throw-error $'No package matching version `($version)`'
     }
 
+    if $pkg.dirty {
+        throw-error ($'Content of package file `($pkg.path)'
+            + $'` does not match expected hash.')
+    }
+
     print $pkg
 
     if $pkg.type == 'git' {

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -207,11 +207,6 @@ def fetch-package [
         throw-error $'No package matching version `($version)`'
     }
 
-    if $pkg.dirty {
-        throw-error ($'Content of package file `($pkg.path)'
-            + $'` does not match expected hash.')
-    }
-
     print $pkg
 
     if $pkg.type == 'git' {

--- a/nupm/search.nu
+++ b/nupm/search.nu
@@ -10,7 +10,7 @@ export def main [
     --pkg-version(-v): string  # Package version to install
     --exact-match(-e)  # Match package name exactly
 ]: nothing -> table {
-    search-package $package --registry $registry --exact-match=$exact_match --skip-dirty-pkg
+    let result = search-package $package --registry $registry --exact-match=$exact_match
     | flatten
     | each {|row|
         {
@@ -24,4 +24,6 @@ export def main [
         }
     }
     | filter-by-version $pkg_version
+
+    return $result
 }

--- a/nupm/search.nu
+++ b/nupm/search.nu
@@ -13,15 +13,19 @@ export def main [
     search-package $package --registry $registry --exact-match=$exact_match
     | flatten
     | each {|row|
-        {
-            registry_name: $row.registry_name
-            registry_path: $row.registry_path
-            name: $row.pkgs.name
-            version: $row.pkgs.version
-            path: $row.pkgs.path
-            type: $row.pkgs.type
-            info: $row.pkgs.info
+        if $row.pkgs.dirty {
+            null
+        } else {
+            {
+                registry_name: $row.registry_name
+                registry_path: $row.registry_path
+                name: $row.pkgs.name
+                version: $row.pkgs.version
+                path: $row.pkgs.path
+                type: $row.pkgs.type
+                info: $row.pkgs.info
+            }
         }
     }
-    | filter-by-version $pkg_version
+    | compact | filter-by-version $pkg_version
 }

--- a/nupm/search.nu
+++ b/nupm/search.nu
@@ -10,22 +10,18 @@ export def main [
     --pkg-version(-v): string  # Package version to install
     --exact-match(-e)  # Match package name exactly
 ]: nothing -> table {
-    search-package $package --registry $registry --exact-match=$exact_match
+    search-package $package --registry $registry --exact-match=$exact_match --skip-dirty-pkg
     | flatten
     | each {|row|
-        if $row.pkgs.dirty {
-            null
-        } else {
-            {
-                registry_name: $row.registry_name
-                registry_path: $row.registry_path
-                name: $row.pkgs.name
-                version: $row.pkgs.version
-                path: $row.pkgs.path
-                type: $row.pkgs.type
-                info: $row.pkgs.info
-            }
+        {
+            registry_name: $row.registry_name
+            registry_path: $row.registry_path
+            name: $row.pkgs.name
+            version: $row.pkgs.version
+            path: $row.pkgs.path
+            type: $row.pkgs.type
+            info: $row.pkgs.info
         }
     }
-    | compact | filter-by-version $pkg_version
+    | filter-by-version $pkg_version
 }

--- a/nupm/utils/registry.nu
+++ b/nupm/utils/registry.nu
@@ -8,7 +8,7 @@ use misc.nu [check-cols url hash-file]
 export const REG_COLS = [ name path hash ]
 
 # Columns of a registry package file
-export const REG_PKG_COLS = [ name version path type info ]
+export const REG_PKG_COLS = [ name version path type info dirty ]
 
 # Search for a package in a registry
 export def search-package [
@@ -86,19 +86,17 @@ export def search-package [
 
                 let new_hash = $pkg_file_path | hash-file
 
-                if $new_hash != $row.hash {
-                    throw-error ($'Content of package file ($pkg_file_path)'
-                        + $' does not match expected hash ($row.hash)')
-                }
+                # check package hash
+                let dirty = $new_hash != $row.hash
 
-                open $pkg_file_path
+                open $pkg_file_path | insert dirty $dirty
             }
             | flatten
 
             {
                 registry_name: $name
                 registry_path: $registry.path
-                pkgs: $pkgs
+                pkgs: $pkgs,
             }
         }
         | compact

--- a/nupm/utils/registry.nu
+++ b/nupm/utils/registry.nu
@@ -8,7 +8,7 @@ use misc.nu [check-cols url hash-file hash-fn]
 export const REG_COLS = [ name path hash ]
 
 # Columns of a registry package file
-export const REG_PKG_COLS = [ name version path type info hash_mismatch ]
+export const REG_PKG_COLS = [ name version path type info ]
 
 # Search for a package in a registry
 export def search-package [

--- a/nupm/utils/registry.nu
+++ b/nupm/utils/registry.nu
@@ -8,14 +8,13 @@ use misc.nu [check-cols url hash-file]
 export const REG_COLS = [ name path hash ]
 
 # Columns of a registry package file
-export const REG_PKG_COLS = [ name version path type info ]
+export const REG_PKG_COLS = [ name version path type info hash_mismatch ]
 
 # Search for a package in a registry
 export def search-package [
     package: string  # Name of the package
     --registry: string  # Which registry to use (name or path)
     --exact-match  # Searched package name must match exactly
-    --skip-dirty-pkg # Skip packages with failed hash checks
 ] -> table {
     let registries = if (not ($registry | is-empty)) and ($registry in $env.NUPM_REGISTRIES) {
         # If $registry is a valid column in $env.NUPM_REGISTRIES, use that
@@ -87,17 +86,7 @@ export def search-package [
 
                 let new_hash = $pkg_file_path | hash-file
 
-                let dirty = $new_hash != $row.hash
-                if $new_hash != $row.hash {
-                    if $skip_dirty_pkg {
-                        null
-                    } else {
-                        throw-error ($'Content of package file `($url_or_path)'
-                            + $' does not match expected hash `($row.hash)`.')
-                    }
-                } else {
-                    open $pkg_file_path | insert dirty $dirty
-                }
+                open $pkg_file_path | insert hash_mismatch ($new_hash != $row.hash)
             }
             | compact
             | flatten


### PR DESCRIPTION
## Description

The current Hash check in the code will directly cause the program to throw an error. When using Search, if there is even one Hash check failure, no information can be displayed.

I have fixed this issue and retained the error throw in the Install section. However, I don't think it's necessary to make the program fail to run specifically because of this issue.

The possible useful solutions I have thought of, which I can modify if you are willing to accept, are:

1. Automatically ignore all packages with Hash check failures.
2. Give users the right to choose, informing them that the content does not match, but they can still install it.