### PR TITLE
fix hash computations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.10
         with:
-          version: nightly
+          version: "0.100.0"
 
       - name: Show Nushell Version
         run: version

--- a/nupm/utils/registry.nu
+++ b/nupm/utils/registry.nu
@@ -2,7 +2,7 @@
 
 use dirs.nu cache-dir
 use log.nu throw-error
-use misc.nu [check-cols url hash-file]
+use misc.nu [check-cols url hash-file hash-fn]
 
 # Columns of a registry file
 export const REG_COLS = [ name path hash ]
@@ -84,7 +84,7 @@ export def search-package [
                     http get $url | save --force $pkg_file_path
                 }
 
-                let new_hash = $pkg_file_path | hash-file
+                let new_hash = open $pkg_file_path | to nuon | hash-fn
 
                 if $new_hash != $row.hash {
                     throw-error ($'Content of package file ($pkg_file_path)'

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -171,8 +171,3 @@ export def generate-local-registry [] {
         assert equal $actual $expected
     }
 }
-
-export def registry-files-no-newlines [] {
-    assert (ls tests/packages/registry/*nuon
-        | all { not (open $in.name --raw | str contains (char nl)) })
-}

--- a/tests/packages/registry/registry.nuon
+++ b/tests/packages/registry/registry.nuon
@@ -1,1 +1,7 @@
-[[name, path, hash]; [spam_custom, spam_custom.nuon, "md5-90c14f51108a3c067d1f1e11f156ca98"], [spam_module, spam_module.nuon, "md5-c14d7a703fb0e587cf19934c5a397619"], [spam_script, spam_script.nuon, "md5-d7724c6282cc7eb878178b79f8617e29"]]
+[
+    [name, path, hash];
+
+    [spam_custom, spam_custom.nuon, "md5-90c14f51108a3c067d1f1e11f156ca98"],
+    [spam_module, spam_module.nuon, "md5-c14d7a703fb0e587cf19934c5a397619"],
+    [spam_script, spam_script.nuon, "md5-d7724c6282cc7eb878178b79f8617e29"],
+]

--- a/tests/packages/registry/registry.nuon
+++ b/tests/packages/registry/registry.nuon
@@ -1,7 +1,7 @@
 [
     [name, path, hash];
 
-    [spam_custom, spam_custom.nuon, "md5-90c14f51108a3c067d1f1e11f156ca98"],
-    [spam_module, spam_module.nuon, "md5-c14d7a703fb0e587cf19934c5a397619"],
-    [spam_script, spam_script.nuon, "md5-d7724c6282cc7eb878178b79f8617e29"],
+    [spam_custom, spam_custom.nuon, "md5-7b3a5119d1af5a025dae32bcfc7cab96"],
+    [spam_module, spam_module.nuon, "md5-618c7c8ed97b423f111790d97bcd8486"],
+    [spam_script, spam_script.nuon, "md5-ce1b060a68ebb42291e364b5daa6d47a"],
 ]


### PR DESCRIPTION
with Nushell 0.100.0, `to nuon` has changed and now quotes strings that contain a `.`, thus breaking hash computations...

this PR does the following
1. formats the registry NUON file so that it's easier to read and maintain
2. relax the "newline" test on registry files, not sure why we _want_ to have newlines in registry files
3. fix the computation of the hash of pkg files by using `to nuon` instead of `open --raw`
4. pin the Nushell version to 0.100.0 in the CI because having a moving target in a CI is very hard to work with

> **Note**
>
> point 1, 2 and 3 are probably debatable and not mandatory for this PR but it was by far the easiest to get this PR going :yum: 