### PR TITLE
docs: added basic usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ $env.PATH = (
 
 ## :rocket: usage [[toc](#table-of-content)]
 
-The following uses a fictional `foo` package for examples.
+Nupm can install different types of packages, such as modules and scripts. It also provides a mechanism for a custom installation using a `build.nu` file.
+
+As an illustrative example, the following demonstrates use of a fictional `foo` module-based package.
 
 ### install a package [[toc](#table-of-content)]
 
@@ -69,16 +71,17 @@ nupm install foo --path
 
 ### update a package [[toc](#table-of-content)]
 
-Assuming the repository is already cloned, you can update the package with the following:
+Assuming the repository is already cloned, you can update the module package with the following:
 
 ```nushell
 do { cd foo; git pull }
 nupm install foo --force --path
 ```
+This usage will likely change once a dedicated `nupm update` command is added.
 
 ### define a package [[toc](#table-of-content)]
 
-In order to use a package with Nupm, a directory should be structured similar to the following `foo` module:
+In order to use a module-based package with Nupm, a directory should be structured similar to the following `foo` module:
 
 - `foo/`
     - `mod.nu`
@@ -95,6 +98,8 @@ The `nupm.nuon` file is a metadata file that describes the package. It should co
     license: "MIT"
 }
 ```
+
+Nupm also supports other types of packages. See [Project Structure](https://github.com/nushell/nupm/blob/main/docs/design/README.md#project-structure-toc) for more details.
 
 ## :test_tube: running a test suite [[toc](#table-of-content)]
 as it is done in Nupm, one can define tests in a project and run them with the `nupm test` command:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 ## Table of content
 - [*installation*](#recycle-installation-toc)
 - [*configuration*](#gear-configuration-toc)
+- [*usage*](#rocket-usage-toc)
+  - [*install a package*](#install-a-package-toc)
+  - [*update a package*](#update-a-package-toc)
+  - [*define a package*](#define-a-package-toc)
 - [*running a test suite*](#test_tube-running-a-test-suite-toc)
-    - [*run the tests*](#run-the-tests-of-Nupm-toc)
+  - [*run the tests*](#run-the-tests-of-Nupm-toc)
 - [*design*](#memo-design-of-nupm-toc)
 
 :warning: **This project is in an experimentation stage and not intended for serious use!** :warning:
@@ -20,10 +24,10 @@
 Both of the above commands will make `nupm` and all its subcommands available in your current scope. `overlay use` will allow you to `overlay hide` the `nupm` overlay when you don't need it.
 
 > **Note**
-> `nupm` is able to install itself: from inside the root of your local copy of `nupm`, run
+> `nupm` is able to install itself: from outside the root of your local copy of `nupm`, run
 > ```nushell
-> use nupm/
-> nupm install --force --path .
+> use nupm/nupm
+> nupm install nupm --force --path
 > ```
 
 ## :gear: configuration [[toc](#table-of-content)]
@@ -50,6 +54,46 @@ $env.PATH = (
         | prepend ($env.NUPM_HOME | path join "scripts")
         | uniq
 )
+```
+
+## :rocket: usage [[toc](#table-of-content)]
+
+The following uses a fictional `foo` package for examples.
+
+### install a package [[toc](#table-of-content)]
+
+```nushell
+git clone https://github.com/nushell/foo.git
+nupm install foo --path
+```
+
+### update a package [[toc](#table-of-content)]
+
+Assuming the repository is already cloned, you can update the package with the following:
+
+```nushell
+do { cd foo; git pull }
+nupm install foo --force --path
+```
+
+### define a package [[toc](#table-of-content)]
+
+In order to use a package with Nupm, a directory should be structured similar to the following `foo` module:
+
+- `foo/`
+    - `mod.nu`
+    - (other scripts and modules)
+- `nupm.nuon`
+
+The `nupm.nuon` file is a metadata file that describes the package. It should contain the following fields:
+
+```nushell
+{
+    name: "foo"
+    description: "A package that demonstrates use of Nupm"
+    type: "module"
+    license: "MIT"
+}
 ```
 
 ## :test_tube: running a test suite [[toc](#table-of-content)]

--- a/docs/design/references/METADATA.md
+++ b/docs/design/references/METADATA.md
@@ -12,7 +12,7 @@
 - `supported-os`: Operating systems supported by the package, the most broad possibility: `{"arch": ["*"], "family": ["*"], "name": ["*"]}`. Matched by `$nu.os-info`
 - `url`: Package website/GitHub repository. Basically a place where one can find some additional info about the package
 
-## Optional attribtues
+## Optional attributes
 - `dependencies`: Packages needed by the package — versions have to be specified. e.g. `[nupm/0.7.0]`. Semantic versioning is also supported: `[nupm/~0.7]`
 - `installer`: Name of a script (relative to the package scope) that will install the package instead (or in addition to) of default `nupm` logic
 - `keywords`: List of keywords used by `nupm search` in addition to `name`


### PR DESCRIPTION
## Description
Getting started with Nupm's current basic functionality required reverse-engineering the needed commands from the code, so I thought a good start would be to define this in the readme.

Some of the existing detailed commands weren't quite accurate so I've also fixed those.

Note that I'm only documenting the functionality I've used for now. It probably makes sense to add the registry stuff once it's more fleshed out.