### PR TITLE
Fix bitrot due to recent typechecking changes

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -13,7 +13,7 @@ def install-scripts [
     pkg_dir: path        # Package directory
     scripts_dir: path    # Target directory where to install
     --force(-f)          # Overwrite already installed scripts
-]: list<path> -> nothing {
+]: [list<path> -> nothing] {
     each {|script|
         let src_path = $pkg_dir | path join $script
 

--- a/nupm/utils/package.nu
+++ b/nupm/utils/package.nu
@@ -27,6 +27,8 @@ export def open-package-file [dir: path] {
         )
     }
 
+    # TODO: Verify types of each field
+
     $package
 }
 
@@ -60,9 +62,9 @@ export def list-package-files [pkg_dir: path, pkg: record]: nothing -> list<path
         }
     }
 
-    $files ++= ($pkg.scripts?
+    $files ++= [($pkg.scripts?
         | default []
-        | each {|script| $pkg_dir | path join $script})
+        | each {|script| $pkg_dir | path join $script})]
 
     $files
 }

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -128,7 +128,7 @@ export def nupm-status-module [] {
         let files = (nupm status tests/packages/spam_module).files
         assert ($files.0 ends-with (
             [tests packages spam_module spam_module mod.nu] | path join))
-        assert ($files.1 ends-with (
+        assert ($files.1.0 ends-with (
             [tests packages spam_module script.nu] | path join))
     }
 }

--- a/tests/packages/spam_module/nupm.nuon
+++ b/tests/packages/spam_module/nupm.nuon
@@ -2,5 +2,5 @@
     name: spam_module,
     type: module,
     version: "0.1.0"
-    scripts: script.nu
+    scripts: [script.nu]
 }


### PR DESCRIPTION
Typechecking got tightened in the recent Nushell updates, which caused some hidden bugs to surface. This PR attempts to fix at least those that caused test failures.