### PR TITLE
docs: add examples documentation to subcommands

### DIFF
--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,7 +1,7 @@
-{
-    name: nupm
-    type: module
-    version: "0.2.0"
-    description: "Nushell package manager"
-    license: "LICENSE"
+
+    name: nupm,
+    type: module,
+    version: "0.2.0",
+    description: "Nushell package manager",
+    license: "LICENSE",
 }

--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -153,7 +153,7 @@ def download-pkg [
     let pkg_dir = if $pkg.path == null {
         $env.PWD | path join $clone_dir
     } else {
-        $env.PWD | path join $clone_dir ($pkg.path | path dirname)
+        $env.PWD | path join $clone_dir $pkg.path
     }
 
     if ($pkg_dir | path exists) {
@@ -233,7 +233,7 @@ def fetch-package [
 # 1. Fetching the package (if the package is online)
 # 2. Installing the package (build action, if any; copy files to install location)
 export def main [
-    package  # Name, path, or link to the package
+    package # Name, path, or link to the package
     --registry: string@complete-registries  # Which registry to use (either a name
                                             # in $env.NUPM_REGISTRIES or a path)
     --pkg-version(-v): string  # Package version to install

--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -28,13 +28,28 @@ export-env {
     # TODO: Add `nupm registry add/remove` to add/remove registry from the env?
     $env.NUPM_REGISTRIES = ($env.NUPM_REGISTRIES?
         | default $DEFAULT_NUPM_REGISTRIES)
-        
+
     use std/log []
 }
 
 # Nushell Package Manager
-export def main []: nothing -> nothing {
+#
+# nupm is a package manager for Nushell that allows you to install, manage, and publish
+# Nushell packages including modules, scripts, and custom packages.
+#
+# Configuration:
+#   Set `NUPM_HOME` environment variable to change installation directory
+#   Set `NUPM_REGISTRIES` to configure package registries
+@example "Install a package from a local directory" { nupm install my-package --path }
+@example "Publish a package" { nupm publish my-registry.nuon --local --save }
+@example "Search for specific version" { nupm search my-package --pkg-version 1.2.0 }
+@example "Check status of specific package directory" { nupm status ./my-package }
+@example "Run tests" { nupm test }
+export def main [subcommand?]: nothing -> nothing {
     nupm-home-prompt --no-confirm=false
+
+    let subcommands = help modules | where name == nupm | get submodules.0.name
+    print $"(ansi green)Usage(ansi reset): nupm \(($subcommands | str join '|'))"
 
     print 'enjoy nupm!'
 }

--- a/nupm/publish.nu
+++ b/nupm/publish.nu
@@ -6,17 +6,19 @@ use utils/version.nu sort-by-version
 
 # Publish package to registry
 #
-# The package being published is determined by the current working directory.
+# Publishes the package in the current working directory to a registry.
+# The package must have a nupm.nuon metadata file.
 #
 # By default, changes are only previewed. To apply them, use the --save flag.
-# Needs to run from package root, i.e., where nupm.nuon is.
-#
-# The --path flag defines the `path` field of the registry package file. Its
-# meaning depends on the package type:
-# * git packages   : Path to the package relative to git repo root
-# * local packages : Path to the package relative to registry file
-# Furthermore, `\` inside the `path` field are  replaced with `/` to avoid
-# conflicts between Windows and non-Windows platforms.
+@example "Publish with additional package info" {
+  nupm publish my-registry.nuon --git --info {url: "https://github.com/user/repo", revision: "main"}
+}
+@example "Publish git package with custom path" {
+  nupm publish my-registry.nuon --git --path packages/my-package
+}
+@example "Publish and save to local registry" {
+  nupm publish my-registry.nuon --local --save
+}
 export def main [
     registry: string  # Registry file to publish to (local file or name pointing
                       # at a local registry)
@@ -53,7 +55,7 @@ export def main [
             | sort-by-version
 
         if ($res | is-empty) {
-            throw-error ($"Cannot guess package type because pacakge"
+            throw-error ($"Cannot guess package type because package"
                 + $" ($pkg.name) was not found in registry ($registry). Specify"
                 + " the type manually with --git or --local flag.")
         }

--- a/nupm/search.nu
+++ b/nupm/search.nu
@@ -3,6 +3,22 @@ use utils/registry.nu search-package
 use utils/version.nu filter-by-version
 
 # Search for a package
+#
+# Search for packages by name across configured registries. Returns a table
+# with package information including name, version, registry, and metadata.
+@example "Search for packages containing 'logger'" {
+  nupm search logger
+}
+@example "Search for exact package name" {
+  nupm search my-package --exact-match
+}
+@example "Search in specific registry" {
+  nupm search logger --registry my-registry
+}
+@example "Search for specific version" {
+  nupm search my-package --pkg-version 1.2.0
+}
+@category "nupm subcommand"
 export def main [
     package  # Name, path, or link to the package
     --registry: string@complete-registries  # Which registry to use (either a name

--- a/nupm/status.nu
+++ b/nupm/status.nu
@@ -2,7 +2,20 @@ use utils/log.nu throw-error
 use utils/package.nu [open-package-file list-package-files]
 
 
-# Display status of a package
+# Display status and information about a package
+#
+# Shows package metadata and lists all files that would be included
+# in the package installation. Useful for inspecting package contents
+# before installation or for debugging package structure.
+@example "Check status of current directory package" {
+  nupm status
+}
+@example "Check status of specific package directory" {
+  nupm status ./my-package
+}
+@example "View package files and metadata" {
+  nupm status ./my-package | get files
+}
 export def main [
     path?: path  # path to the package
 ]: nothing -> record<filename: string> {

--- a/nupm/test.nu
+++ b/nupm/test.nu
@@ -1,7 +1,23 @@
 use utils/dirs.nu [ tmp-dir find-root ]
 use utils/log.nu throw-error
 
-# Experimental test runner
+# Run tests for a nupm package
+#
+# Discovers and runs all exported test functions from the tests/ directory.
+# Tests are Nushell functions that should throw errors on failure.
+# The test runner provides isolated environments and reports results.
+@example "Run all tests in current package" {
+  nupm test
+}
+@example "Run tests matching a filter" {
+  nupm test install
+}
+@example "Run tests from specific directory" {
+  nupm test --dir ./my-package
+}
+@example "Show test output for debugging" {
+  nupm test --show-stdout
+}
 export def main [
     filter?: string  = ''  # Run only tests containing this substring
     --dir: path  # Directory where to run tests (default: $env.PWD)

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -12,7 +12,7 @@ export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
 
 # Default registry
 export const DEFAULT_NUPM_REGISTRIES = {
-    nupm_test: 'https://raw.githubusercontent.com/nushell/nupm/main/registry/registry.nuon'
+    nupm: 'https://raw.githubusercontent.com/nushell/nupm/main/registry/registry.nuon'
 }
 
 # Prompt to create $env.NUPM_HOME if it does not exist and some sanity checks.

--- a/nupm/utils/version.nu
+++ b/nupm/utils/version.nu
@@ -12,7 +12,7 @@ export def filter-by-version [version: any]: table<version: string> -> table<ver
     if $version == null {
         $in
     } else {
-        $in | filter {|row| $row.version | matches-version $version}
+        $in | where {|row| $row.version | matches-version $version}
     }
     | sort-by-version
 }


### PR DESCRIPTION
<!-- related issues, e.g. "will close #123" -->

## Description
* Added [`@example`](https://github.com/nushell/nushell/pull/14906) attribute to `nupm` and subcommands
* Fixed incorrect handling of registry `path` value in git installs
* renamed default registry `nupm_test` to `nupm` to avoid confusion with the [nupm test registry](https://github.com/nushell/nupm/blob/f4c4007531a16ecc07ba6f829e46316046b26564/tests/mod.nu#L10-L13)
