### PR TITLE
Fix deprecated `get -i` flag; Fix unreliable test

### DIFF
--- a/nupm/publish.nu
+++ b/nupm/publish.nu
@@ -222,7 +222,7 @@ def guess-revision []: nothing -> string {
 
 def get-registry-path []: string -> path {
     let registry = $in
-    $env.NUPM_REGISTRIES | get -i $registry | default ($registry | path expand)
+    $env.NUPM_REGISTRIES | get -o $registry | default ($registry | path expand)
 }
 
 def open-registry-file []: path -> table<name: string, path: string, url: string> {

--- a/nupm/utils/package.nu
+++ b/nupm/utils/package.nu
@@ -20,7 +20,7 @@ export def open-package-file [dir: path] {
     log debug "checking package file for missing required keys"
     let required_keys = [$. $.name $.version $.type]
     let missing_keys = $required_keys
-        | where {|key| ($package | get -i $key) == null}
+        | where {|key| ($package | get -o $key) == null}
     if not ($missing_keys | is-empty) {
         throw-error "invalid_package_file" (
             $"($package_file) is missing the following required keys:"

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -146,7 +146,9 @@ export def env-vars-are-set [] {
     assert equal $env.NUPM_HOME $dirs.DEFAULT_NUPM_HOME
     assert equal $env.NUPM_TEMP $dirs.DEFAULT_NUPM_TEMP
     assert equal $env.NUPM_CACHE $dirs.DEFAULT_NUPM_CACHE
-    assert equal $env.NUPM_REGISTRIES $dirs.DEFAULT_NUPM_REGISTRIES
+    (assert equal
+        $env.NUPM_REGISTRIES
+        ($env.NUPM_REGISTRIES | merge $dirs.DEFAULT_NUPM_REGISTRIES))
 }
 
 export def generate-local-registry [] {


### PR DESCRIPTION
* Replaces the deprecated `get -i` with `get -o`
* `$env.NUPM_REGISTRIES` is set on `nupm` startup by reading the index file. If the index file contains some custom entries, testing it for the default value would fail. Now the test just checks if the default value is present. cc https://github.com/nushell/nupm/pull/122