### PR TITLE
fix: replace deprecated $nu.temp-path with $nu.temp-dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.10
         with:
-          version: "0.106.1"
+          version: "0.110.0"
 
       - name: Show Nushell Version
         run: version

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -8,7 +8,7 @@ export const DEFAULT_NUPM_CACHE = ($nu.default-config-dir
     | path join nupm cache)
 
 # Default temporary path for various nupm purposes
-export const DEFAULT_NUPM_TEMP = ($nu.temp-path | path join "nupm")
+export const DEFAULT_NUPM_TEMP = ($nu.temp-dir | path join "nupm")
 
 # registry index filename
 export const REGISTRY_IDX_FILENAME = "registry_index.nuon"


### PR DESCRIPTION
## Description
Fixed nupm startup error after nushell version update.
[nushell version 0.110.0 renamed $nu.temp-path and $nu.home-path](https://www.nushell.sh/blog/2026-01-17-nushell_v0_110_0.html#renamed-nu-temp-path-and-nu-home-path-toc)
