### PR TITLE
Update Nushell version to 0.110.0 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.10
         with:
-          version: "0.106.1"
+          version: "0.110.0"
 
       - name: Show Nushell Version
         run: version


### PR DESCRIPTION
Makes tests pass in #127 by using the newest version (`v0.110.0`) of Nushell in the CI pipeline.