### PR TITLE
Update Nushell version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.10
         with:
-          version: "0.106.1"
+          version: "0.110.0"
 
       - name: Show Nushell Version
         run: version


### PR DESCRIPTION
Updates Nushell to the newest version as in https://github.com/nushell/nupm/pull/128 which was closed by the author.

