### PR TITLE
Fix Git Registry Installations

### DIFF
--- a/nupm/install.nu
+++ b/nupm/install.nu
@@ -174,7 +174,7 @@ def download-pkg [
         throw-error $'Error cloning repository ($pkg.info.url)'
     }
     (
-        assert (not ($pkg_dir | path exists))
+        assert ($pkg_dir | path exists)
         $'Package path ($pkg.path) does not exist in cloned repository'
         --error-label={text: "path_missing", span:(metadata $pkg_dir | get span)}
     )

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -94,7 +94,7 @@ export def install-from-local-registry [] {
 
     with-test-env {
         $env.NUPM_GIT_CLONE_ARGS = [
-            "--reference"
+            "--reference-if-able"
             ($DIRNAME | path join ".." | path expand)
             "--revision"
             (git rev-parse HEAD)

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -1,9 +1,10 @@
-use std assert
+use std/assert
 
 use ../nupm/utils/dirs.nu
 use ../nupm/utils/dirs.nu [ tmp-dir REGISTRY_FILENAME ]
 use ../nupm
 
+const DIRNAME = path self .
 const TEST_REGISTRY_PATH = ([tests packages registry $REGISTRY_FILENAME] | path join)
 
 
@@ -90,6 +91,17 @@ export def install-from-local-registry [] {
         nupm install spam_script
         check-file-content 0.2.0
     }
+
+    with-test-env {
+        $env.NUPM_GIT_CLONE_ARGS = [
+            "--reference"
+            ($DIRNAME | path join ".." | path expand)
+            "--revision"
+            (git rev-parse HEAD)
+        ]
+
+        nupm install spam_git
+    }
 }
 
 export def install-with-version [] {
@@ -129,7 +141,7 @@ export def install-package-not-found [] {
 
 export def search-registry [] {
     with-test-env {
-        assert ((nupm search spam | length) == 4)
+        assert ((nupm search spam | length) == 5)
     }
 }
 
@@ -175,6 +187,12 @@ export def generate-local-registry [] {
         [spam_script spam_script_old spam_custom spam_module] | each {|pkg|
             cd ([tests packages $pkg] | path join)
             nupm publish $tmp_reg_file --local --save --path (".." | path join $pkg)
+        }
+
+        do {
+            let pkg = "spam_git"
+            cd ([tests packages $pkg] | path join)
+            nupm publish $tmp_reg_file --git --save --info {url: "https://github.com/nushell/nupm.git" revision: "main"} --path $"tests/packages/($pkg)"
         }
 
         let actual = open $tmp_reg_file | to nuon

--- a/tests/packages/registry/registry.nuon
+++ b/tests/packages/registry/registry.nuon
@@ -2,6 +2,7 @@
     [name, path, hash];
 
     [spam_custom, spam_custom.nuon, "md5-7b3a5119d1af5a025dae32bcfc7cab96"],
+    [spam_git, spam_git.nuon, "md5-6d79981218772b4b130cb5d48b15a70f"],
     [spam_module, spam_module.nuon, "md5-618c7c8ed97b423f111790d97bcd8486"],
     [spam_script, spam_script.nuon, "md5-ce1b060a68ebb42291e364b5daa6d47a"],
 ]

--- a/tests/packages/registry/spam_git.nuon
+++ b/tests/packages/registry/spam_git.nuon
@@ -1,0 +1,1 @@
+[[name, version, path, type, info]; [spam_git, "0.1.0", tests/packages/spam_git, git, {url: "https://github.com/nushell/nupm.git", revision: main}]]

--- a/tests/packages/spam_git/nupm.nuon
+++ b/tests/packages/spam_git/nupm.nuon
@@ -1,0 +1,6 @@
+{
+    name: spam_git,
+    type: module,
+    version: "0.1.0"
+    scripts: [script.nu]
+}

--- a/tests/packages/spam_git/script.nu
+++ b/tests/packages/spam_git/script.nu
@@ -1,0 +1,1 @@
+print 'git'

--- a/tests/packages/spam_git/spam_git/mod.nu
+++ b/tests/packages/spam_git/spam_git/mod.nu
@@ -1,0 +1,3 @@
+export def main [] {
+    "Hello Git!"
+}


### PR DESCRIPTION
As mentioned in #133, an inverted `assert`ion causes all installations of `git` packages from registries to fail.

## Description
Changes made in this commit add a test to proof this error and gets rid of the incorrect `assert`ion.
Merging this PR will fix #108 and fix #133