### PR TITLE
Fix nushell 114

### DIFF
--- a/nupm/mod.nu
+++ b/nupm/mod.nu
@@ -7,12 +7,12 @@ use utils/dirs.nu [
 
 use utils/registry.nu open-index
 
-export module install.nu
-export module publish.nu
-export module registry.nu
-export module search.nu
-export module status.nu
-export module test.nu
+export use install.nu
+export use publish.nu
+export use registry.nu
+export use search.nu
+export use status.nu
+export use test.nu
 
 
 export-env {

--- a/nupm/publish.nu
+++ b/nupm/publish.nu
@@ -81,7 +81,7 @@ export def main [
         []
     }
 
-    mut existing_entry = null
+    mut existing_entry: oneof<nothing, record> = null
 
     if ($name_matches | length) == 1 {
         $existing_entry = ($name_matches | first)
@@ -225,7 +225,7 @@ def get-registry-path []: string -> path {
     $env.NUPM_REGISTRIES | get -o $registry | default ($registry | path expand)
 }
 
-def open-registry-file []: path -> table<name: string, path: string, url: string> {
+def open-registry-file []: path -> table<name: string, path: string, hash: string> {
     let reg_path = $in
 
     let reg_content = try { open $reg_path }
@@ -245,7 +245,7 @@ def open-reg-pkg-file []: [ path -> table<
         version: string
         path: string
         type: string
-        info: record<url: string, revision: string>> ] {
+        info: oneof<nothing, record<url: string, revision: string>>> ] {
     let pkg_path = $in
 
     let pkg_content = try { open $pkg_path }

--- a/nupm/utils/package.nu
+++ b/nupm/utils/package.nu
@@ -36,7 +36,7 @@ export def open-package-file [dir: path] {
 # Lists files of a package
 #
 # This will be useful for file integrity checks
-export def list-package-files [pkg_dir: path, pkg: record]: nothing -> list<path> {
+export def list-package-files [pkg_dir: path, pkg: record]: nothing -> list<oneof<path, list<path>>> {
     let activation = match $pkg.type {
         'module' => $'use ($pkg.name)'
         'script' => {

--- a/tests/mod.nu
+++ b/tests/mod.nu
@@ -1,4 +1,4 @@
-use std assert
+use std/assert
 
 use ../nupm/utils/dirs.nu
 use ../nupm/utils/dirs.nu [ tmp-dir REGISTRY_FILENAME ]


### PR DESCRIPTION
## Description
The current version of `nupm` doesn't support the most recent `nushell` version v0.114.0.
Changes made in this PR will make changes according to new requirements of `nushell` v0.114.0.

Changes made in this commit will fix #131.