### PR TITLE
Migrate to New Commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: hustcer/setup-nu@v3.10
         with:
-          version: "0.110.0"
+          version: "0.114.0"
 
       - name: Show Nushell Version
         run: version

--- a/nupm/utils/dirs.nu
+++ b/nupm/utils/dirs.nu
@@ -62,13 +62,13 @@ export def nupm-home-prompt [--no-confirm]: nothing -> bool {
 
     mut answer = ''
 
-    while ($answer | str downcase) not-in [ y n ] {
+    while ($answer | str lowercase) not-in [ y n ] {
         $answer = (input (
             $'Root directory "($env.NUPM_HOME)" does not exist.'
             + ' Do you want to create it? [y/n] '))
     }
 
-    if ($answer | str downcase) not-in [ y Y ] {
+    if ($answer | str lowercase) not-in [ y Y ] {
         return false
     }
 

--- a/nupm/utils/package.nu
+++ b/nupm/utils/package.nu
@@ -48,9 +48,11 @@ export def list-package-files [pkg_dir: path, pkg: record]: nothing -> list<oneo
 
     let src = $"
         ($activation)
+        let pkg_dir = echo ($pkg_dir) | path split
         view files
-        | where \($it.filename | str starts-with ($pkg_dir)\)
+        | where \($it.filename | path split | take \($pkg_dir | length\)\) == $pkg_dir
         | get filename
+        | path expand
         | to nuon"
 
     mut files = []


### PR DESCRIPTION
## Description
In nushell/nushell#18364, `str downcase` has been deprecated in favor of `str lowercase`.
Changes made in this PR will change the code accordingly and thus fix #132.

This PR will, however, break support for nushell v0.113, as the `str lowercase` command doesn't exist before nushell v0.114.0.