### PR TITLE
Better Linux default dirs example, formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
 > If that is the case, consider building Nushell from the `main` branch, or installing the [nightly build](https://github.com/nushell/nightly).
 
 `nupm` is a module. Download the repository and treat the [`nupm`](https://github.com/nushell/nupm/tree/main/nupm`) directory as a module. For example:
-* `use nupm/`
-* `overlay use nupm/ --prefix`
+
+```nushell
+use nupm/
+overlay use nupm/ --prefix
+```
 
 Both of the above commands will make `nupm` and all its subcommands available in your current scope. `overlay use` will allow you to `overlay hide` the `nupm` overlay when you don't need it.
 
@@ -32,11 +35,12 @@ Both of the above commands will make `nupm` and all its subcommands available in
 > ```
 
 ## :gear: configuration [[toc](#table-of-content)]
-One can change the location of the Nupm directory with `$env.NUPM_HOME`, e.g.
+One can change the location of the Nupm directory with `$env.NUPM_HOME`, e.g. for systemd Linux
 ```nushell
 # env.nu
 
-$env.NUPM_HOME = ($env.XDG_DATA_HOME | path join "nupm")
+$env.NUPM_HOME  = (systemd-path user-shared      | path join "nupm") # ~/.local/share/nupm (systemd Linux default)
+$env.NUPM_CACHE = (systemd-path user-state-cache | path join "nupm") # ~/.cache/nupm       (systemd Linux default)
 ```
 
 Because Nupm will install modules and scripts in `{{nupm-home}}/modules/` and `{{nupm-home}}/scripts/` respectively, it is a good idea to add these paths to `$env.NU_LIB_DIRS` and `$env.PATH` respectively, e.g. if you have `$env.NUPM_HOME` defined:


### PR DESCRIPTION
Better example for Linux

<!-- related issues, e.g. "will close #123" -->

## Description
`$env.XDG_DATA_HOME` is not even set by default

Here is some AI copy pasta:

**XDG_DATA_HOME is not set by default on most standard Linux distributions** (such as Ubuntu, Fedora, or Arch); the environment variable is typically unset unless a user manually defines it or a specific sandboxed environment (like **Flatpak**) overrides it.

According to the **Freedesktop.org XDG Base Directory Specification**, if the variable is unset or empty, applications are expected to use the default path **$HOME/.local/share** for storing user-specific data files.

*   **Linux/BSD**: The variable is generally **unset by default**. It is only set if explicitly configured in shell profiles (e.g., ~/.profile, ~/.bashrc) or by desktop environments and sandbox runtimes like **Flatpak**.
*   **macOS**: The specification maps this role to **$HOME/Library/Application Support** rather than using the Linux-style `$HOME/.local/share` structure.
*   **Windows**: There is no direct XDG equivalent; Windows typically uses **%AppData%** or **%LocalAppData%**.

Therefore, the XDG Base Directory environment variables, including **XDG_DATA_HOME**, are primarily a **Linux/Unix** convention designed to declutter the home directory, and they are not active or set by default in standard desktop Linux installations.


